### PR TITLE
Notifications now always go to the reviewer path when clicked on, even i...

### DIFF
--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -4,9 +4,7 @@ class PersonDecorator < ApplicationDecorator
   def proposal_path(proposal)
     event = proposal.event
 
-    if object.organizer_for_event?(event)
-      h.organizer_event_proposal_path(event, proposal)
-    elsif object.reviewer_for_event?(event)
+    if object.organizer_for_event?(event) || object.reviewer_for_event?(event)
       h.reviewer_event_proposal_path(event, proposal)
     else
       h.proposal_path(event.slug, proposal)

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -6,8 +6,8 @@ describe NotificationsController, type: :controller do
 
   describe "GET 'index'" do
     it "returns http success" do
-      get 'index'
-      response.should be_success
+      get :index
+      expect(response).to be_success
     end
 
     it "redirects an unauthenticated user" do
@@ -18,15 +18,15 @@ describe NotificationsController, type: :controller do
   end
 
   describe "GET 'show'" do
-    it "returns http success" do
-      notification = create(:notification, person: person)
-      get 'show', id: notification
-      response.should be_redirect
+    it "redirects to the notification's target path" do
+      notification = create(:notification, person: person, target_path: "/something/awesome")
+      get :show, id: notification
+      expect(response).to redirect_to "/something/awesome"
     end
 
     it "sets notification as read" do
       notification = create(:notification, read_at: nil, person: person)
-      get 'show', id: notification
+      get :show, id: notification
       expect(notification.reload).to be_read
     end
   end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 describe PersonDecorator do
   describe "#proposal_path" do
-    it "returns the path for a speaker" do
+    it "returns the regular path for a speaker" do
       speaker = create(:speaker)
       proposal = create(:proposal, speakers: [ speaker ])
       expect(speaker.person.decorate.proposal_path(proposal)).to(
         eq(h.proposal_path(proposal.event.slug, proposal)))
     end
 
-    it "returns the path for an organizer" do
+    it "returns the reviewer path for an organizer" do
       organizer = create(:organizer)
       proposal = create(:proposal)
       expect(organizer.decorate.proposal_path(proposal)).to(
-        eq(h.organizer_event_proposal_path(proposal.event, proposal)))
+        eq(h.reviewer_event_proposal_path(proposal.event, proposal)))
     end
 
-    it "returns the path for a reviewer" do
+    it "returns the reviewer path for a reviewer" do
       reviewer = create(:person, :reviewer)
       proposal = create(:proposal)
       expect(reviewer.decorate.proposal_path(proposal)).to(


### PR DESCRIPTION
...f the current user is an organizer, to preserve anonymity during the review phase.
