### PR TITLE
Don't urge speakers to tweet their proposal, because nobody should see i...

### DIFF
--- a/app/views/proposals/confirm.html.haml
+++ b/app/views/proposals/confirm.html.haml
@@ -4,7 +4,6 @@
       %h1
         Confirm
         = proposal.title
-      = link_to 'Tweet', 'https://twitter.com/share', class: 'twitter-share-button', data: { text: "Check out this #{proposal.event} proposal: #{proposal.title}" }
   .row
     .col-md-8
       %p.help-block Congratulations! Your talk has been #{proposal.state}. Please ensure the information below is correct.

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -3,7 +3,6 @@
     .col-md-8
       %h1
         = proposal.title
-      = link_to 'Tweet', 'https://twitter.com/share', class: 'twitter-share-button', data: { text: "Check out this #{event} proposal: #{proposal.title}" }
     .col-md-4
       - if proposal.has_speaker?(current_user)
         .toolbox.pull-right


### PR DESCRIPTION
...t anyway. 

I think these were a vestige of the old code in which submissions would potentially be public.
