### PR TITLE
Fixing all RSpec deprecation warnings

### DIFF
--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -8,7 +8,7 @@ describe CommentsController, type: :controller do
     let(:mailer) { double("ProposalMailer.comment_notification") }
 
     before do
-      Proposal.stub(:find).and_return(proposal)
+      allow(Proposal).to receive(:find).and_return(proposal)
       request.env['HTTP_REFERER'] =  referer_path
     end
 
@@ -20,7 +20,7 @@ describe CommentsController, type: :controller do
       before do
         allow(comment_person).to receive(:reviewer?).and_return(true)
         allow(comment_person).to receive(:reviewer_for_event?).and_return(true)
-        CommentsController.any_instance.stub(current_user: comment_person)
+        allow_any_instance_of(CommentsController).to receive(:current_user) { comment_person }
       end
 
       it "adds a comment to the proposal" do
@@ -42,7 +42,7 @@ describe CommentsController, type: :controller do
       it "sends an email notification to all speakers" do
         speakers = build_list(:speaker, 3)
         proposal = create(:proposal, speakers: speakers)
-        Proposal.stub(:find).and_return(proposal)
+        allow(Proposal).to receive(:find).and_return(proposal)
         expect {
           post :create, params
         }.to change(ActionMailer::Base.deliveries, :count).by(1)

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -7,7 +7,7 @@ describe NotificationsController, type: :controller do
   describe "GET 'index'" do
     it "returns http success" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "redirects an unauthenticated user" do
@@ -21,7 +21,7 @@ describe NotificationsController, type: :controller do
     it "returns http success" do
       notification = create(:notification, person: person)
       get 'show', id: notification
-      response.should be_redirect
+      expect(response).to be_redirect
     end
 
     it "sets notification as read" do

--- a/spec/controllers/organizer/participants_controller_spec.rb
+++ b/spec/controllers/organizer/participants_controller_spec.rb
@@ -13,7 +13,7 @@ describe Organizer::ParticipantsController, type: :controller do
 
 
     context "A valid organizer" do
-      before { controller.stub(:current_user).and_return(organizer_user) }
+      before { allow(controller).to receive(:current_user).and_return(organizer_user) }
 
       it "creates a new participant" do
         post :create, participant: { role: 'reviewer' }, email: 'foo@bar.com', event_id: event.id
@@ -35,7 +35,7 @@ describe Organizer::ParticipantsController, type: :controller do
     end
 
     context "A non-organizer" do
-      before { controller.stub(:current_user).and_return(other_user) }
+      before { allow(controller).to receive(:current_user).and_return(other_user) }
 
       it "returns 404" do
         expect {
@@ -52,7 +52,7 @@ describe Organizer::ParticipantsController, type: :controller do
       before do
         create(:participant, person: sneaky_organizer, event: event2,
                role: 'organizer')
-        controller.stub(:current_user).and_return(sneaky_organizer)
+        allow(controller).to receive(:current_user).and_return(sneaky_organizer)
       end
 
       it "cannot create participants for different events" do

--- a/spec/controllers/organizer/proposals_controller_spec.rb
+++ b/spec/controllers/organizer/proposals_controller_spec.rb
@@ -12,7 +12,7 @@ describe Organizer::ProposalsController, type: :controller do
   let(:proposal) { create(:proposal, event: event) }
 
   before do
-    ApplicationController.any_instance.stub(:current_user).and_return(person)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(person)
   end
 
   describe "POST 'update_state'" do

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -7,7 +7,7 @@ describe ProfilesController, type: :controller do
       { person: { bio: 'foo', demographics: { gender: 'female' } } }
     }
 
-    before { controller.stub(:current_user).and_return(user) }
+    before { allow(controller).to receive(:current_user).and_return(user) }
 
     it "updates the user record" do
       put :update, params

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -11,7 +11,7 @@ describe SessionsController, type: :controller do
     before :each do
       session[:invitation_slug] = invitation.slug
       request.env['omniauth.auth'] = auth_hash
-      controller.stub(:current_user).and_return(user)
+      allow(controller).to receive(:current_user).and_return(user)
     end
 
     it "adds any pending invitations to the new person record" do

--- a/spec/features/organizer/event_spec.rb
+++ b/spec/features/organizer/event_spec.rb
@@ -35,7 +35,7 @@ feature "Event Dashboard" do
       fill_in "End date", with: DateTime.now + 15.days
       click_button 'Save'
       admin_user.reload
-      admin_user.organizer_events.last.name.should eql("My Other Event")
+      expect(admin_user.organizer_events.last.name).to eql("My Other Event")
     end
 
     it "can edit an event" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -73,7 +73,7 @@ describe Event do
     let(:event) { build :event }
     it 'splits comma separated string into tags' do
       event.valid_proposal_tags = 'one,two,three'
-      event.proposal_tags.should == ['one', 'two', 'three']
+      expect(event.proposal_tags).to match_array ['one', 'two', 'three']
     end
   end
 
@@ -81,7 +81,7 @@ describe Event do
     let(:event) { build :event }
     it 'splits comma separated string into tags' do
       event.valid_review_tags = 'one,two,three'
-      event.review_tags.should == ['one', 'two', 'three']
+      expect(event.review_tags).to match_array ['one', 'two', 'three']
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -40,7 +40,7 @@ describe Notification do
   describe "#read" do
     it "sets read_at to DateTime.now" do
       now = DateTime.now
-      DateTime.stub(now: now)
+      allow(DateTime).to receive(:now) { now }
       notification = create(:notification)
       notification.read
       expect(notification.reload).to be_read

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -103,7 +103,7 @@ describe Person do
 
   describe '#new' do
     it 'should default to non-admin' do
-      Person.new.should_not be_admin
+      expect(Person.new).not_to be_admin
     end
   end
 
@@ -151,11 +151,11 @@ describe Person do
     let(:person) { create(:person, :reviewer) }
 
     it 'is true when reviewer for any event' do
-      person.should be_reviewer
+      expect(person).to be_reviewer
     end
     it 'is false when not reviewer of any event' do
       person.participants.map { |p| p.update_attribute(:role, 'not_reviewer') }
-      person.should_not be_reviewer
+      expect(person).not_to be_reviewer
     end
   end
 
@@ -163,11 +163,11 @@ describe Person do
     let(:person) { create(:person, :organizer) }
 
     it 'is true when organizer for any event' do
-      person.should be_organizer
+      expect(person).to be_organizer
     end
     it 'is false when not organizer of any event' do
       person.participants.map { |p| p.update_attribute(:role, 'not_organizer') }
-      person.should_not be_organizer
+      expect(person).not_to be_organizer
     end
   end
 
@@ -183,10 +183,10 @@ describe Person do
       end
 
       it 'is true when reviewer for the event' do
-        person.should be_reviewer_for_event(event1)
+        expect(person).to be_reviewer_for_event(event1)
       end
       it 'is false when not reviewer of the event' do
-        person.should_not be_reviewer_for_event(event2)
+        expect(person).not_to be_reviewer_for_event(event2)
       end
     end
 
@@ -197,10 +197,10 @@ describe Person do
       end
 
       it 'is true when organizer for the event' do
-        person.should be_organizer_for_event(event1)
+        expect(person).to be_organizer_for_event(event1)
       end
       it 'is false when not organizer of the event' do
-        person.should_not be_organizer_for_event(event2)
+        expect(person).not_to be_organizer_for_event(event2)
       end
     end
   end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -71,8 +71,8 @@ describe Proposal do
     end
 
     it "limits abstracts to 600 characters or less" do
-      build(:proposal, abstract: "S" * 600).should be_valid
-      build(:proposal, abstract: "S" * 601).should_not be_valid
+      expect(build(:proposal, abstract: "S" * 600)).to be_valid
+      expect(build(:proposal, abstract: "S" * 601)).not_to be_valid
     end
   end
 
@@ -272,34 +272,34 @@ describe Proposal do
       proposal.reload
     end
     it 'creates proposal_tags' do
-      proposal.tags.sort.should == ['one', 'two', 'three'].sort
+      expect(proposal.tags).to match_array ['one', 'two', 'three']
     end
     it 'creates review_tags' do
-      proposal.review_tags.sort.should == ['four', 'five', 'six'].sort
+      expect(proposal.review_tags).to match_array ['four', 'five', 'six']
     end
     it "clears proposal_tags if attribute is empty array" do
       proposal.tags = [""] # this is the form param when nothing is checked
       proposal.save
       proposal.reload
-      proposal.tags.should == []
+      expect(proposal.tags).to be_empty
     end
     it "clears review_tags if attribute is empty array" do
       proposal.review_tags = [""] # this is the form param when nothing is checked
       proposal.save
       proposal.reload
-      proposal.review_tags.should == []
+      expect(proposal.review_tags).to be_empty
     end
     it "doesn't reset proposal_tags if attribute not set" do
       proposal.tags = nil # this is the form param if not in form at all
       proposal.save
       proposal.reload
-      proposal.tags.sort.should == ['one', 'two', 'three'].sort
+      expect(proposal.tags).to match_array ['one', 'two', 'three']
     end
     it "doesn't reset review_tags if attribute not set" do
       proposal.review_tags = nil # this is the form param if not in form at all
       proposal.save
       proposal.reload
-      proposal.review_tags.sort.should == ['four', 'five', 'six'].sort
+      expect(proposal.review_tags).to match_array ['four', 'five', 'six']
     end
   end
 
@@ -333,13 +333,13 @@ describe Proposal do
       proposal.ratings.build(score: 4)
       proposal.ratings.build(score: 5)
 
-      proposal.ratings.size.should == 4
-      proposal.average_rating.should == 3.5
+      expect(proposal.ratings.size).to eq(4)
+      expect(proposal.average_rating).to eq(3.5)
     end
 
     it "returns nil if no rating" do
-      proposal.ratings.size.should == 0
-      proposal.average_rating.should be_nil
+      expect(proposal.ratings).to be_empty
+      expect(proposal.average_rating).to be_nil
     end
   end
 

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -13,8 +13,8 @@ describe Rating do
     create :rating, proposal: proposal_in_event2
     create :rating, proposal: proposal_in_event2
 
-    Rating.for_event(event1).count.should eq(1)
-    Rating.for_event(event2).count.should eq(2)
+    expect(Rating.for_event(event1).count).to eq(1)
+    expect(Rating.for_event(event2).count).to eq(2)
   end
 
 end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 describe Tagging do
   describe '.tags_string_to_array' do
     it 'splits comma separated string into tags' do
-      Tagging.tags_string_to_array('one,two,three').should == ['one', 'two', 'three']
+      expect(Tagging.tags_string_to_array('one,two,three')).to match_array ['one', 'two', 'three']
     end
     it 'strips leading and trailing whitespace from tags' do
-      Tagging.tags_string_to_array('  one  , two , three   ').should == ['one', 'two', 'three']
+      expect(Tagging.tags_string_to_array('  one  , two , three   ')).to match_array ['one', 'two', 'three']
     end
     it 'allows whitespace inside a tag' do
-      Tagging.tags_string_to_array('one,two,third element').should == ['one', 'two', 'third element']
+      expect(Tagging.tags_string_to_array('one,two,third element')).to match_array ['one', 'two', 'third element']
     end
     it 'removes extra commas' do
-      Tagging.tags_string_to_array(' ,  one,   ,two , ,three,').should == ['one', 'two', 'three']
+      expect(Tagging.tags_string_to_array(' ,  one,   ,two , ,three,')).to match_array ['one', 'two', 'three']
     end
     it 'removes duplicated tags' do
-      Tagging.tags_string_to_array('one,one,two,three').should == ['one', 'two', 'three']
+      expect(Tagging.tags_string_to_array('one,one,two,three')).to match_array ['one', 'two', 'three']
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 RSpec.configure do |config|
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
+  config.raise_errors_for_deprecations!
 =begin
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -1,7 +1,7 @@
 module FeatureHelper
   def login_user(user)
-    Person.stub(:authenticate).and_return('developer', user)
-    Person.stub(:find_by_id).and_return(user)
+    allow(Person).to receive(:authenticate).and_return('developer', user)
+    allow(Person).to receive(:find_by_id).and_return(user)
     Person.authenticate(user)
   end
 end


### PR DESCRIPTION
I turned on `raise_errors_for_deprecations!` in 
`spec\spec_helper.rb`, that helped me track down
all deprecation warnings. I fixed all of them, 
left this setting in the spec_helper file to enforce
the new RSpec syntax going forward.
