### PR TITLE
Added time zone support to events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,7 +17,7 @@ class Event < ActiveRecord::Base
   serialize :review_tags, Array
 
   scope :recent, -> { order('name ASC') }
-  scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.now).order('closes_at ASC') }
+  scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.current).order('closes_at ASC') }
 
   validates :name, :contact_email, presence: true
   validates :slug, presence: true, uniqueness: true
@@ -49,7 +49,7 @@ class Event < ActiveRecord::Base
   end
 
   def open?
-    state == 'open' && (closes_at.nil? || closes_at > Time.now)
+    state == 'open' && (closes_at.nil? || closes_at > Time.current)
   end
 
   def closed?
@@ -57,7 +57,7 @@ class Event < ActiveRecord::Base
   end
 
   def past_open?
-    state == 'open' && closes_at < Time.now
+    state == 'open' && closes_at < Time.current
   end
 
   def unmet_requirements_for_scheduling


### PR DESCRIPTION
I noticed a bug when looking at my list of proposals for RubyConf Australia.

On the initial list it showed the CFP as open:
![screenshot 2014-10-19 23 05 03](https://cloud.githubusercontent.com/assets/10128/4694740/da0ade1c-57d3-11e4-9403-a98e77124f73.png)

However it was actually closed once I clicked through to the show action:
![screenshot 2014-10-19 23 07 07](https://cloud.githubusercontent.com/assets/10128/4694741/e90f5582-57d3-11e4-9dbc-3a6c6caaf581.png)

This is because the conference is in the Australian time zone and I'm in CEST which is still, currently, Sunday before midnight which is when the CFP closes.

I believe that this patch would fix the issue, though haven't tested it.  It's late, and I just wanted to get the patch discussion open.
