### PR TITLE
Switch gender, ethnicity to free text fields.

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,9 +1,8 @@
 require 'digest/md5'
 
 class Person < ActiveRecord::Base
+  DEMOGRAPHICS      = [:gender, :ethnicity, :country]
   DEMOGRAPHIC_TYPES = {
-    gender: ['female', 'male', 'trans*', 'bigender', 'genderqueer', 'not listed here'],
-    ethnicity: ['African American', 'Asian', 'Caucasian', 'Hispanic', 'Native American', 'Pacific Islander', 'other' ],
     country: CountrySelect::countries.select{ |k,v| k != 'us'}.values.sort.unshift("United States of America")
   }
 

--- a/app/views/admin/people/_form.html.haml
+++ b/app/views/admin/people/_form.html.haml
@@ -11,14 +11,11 @@
         = f.email_field :email, class: 'form-control', placeholder: 'Email address'
       %p
         = f.label :bio
-        = f.text_area :bio, class: 'form-control', placeholder: 'Bio', rows: 8        
+        = f.text_area :bio, class: 'form-control', placeholder: 'Bio', rows: 8
+
     %fieldset.col-md-4
       %h2 Demographics
-      %p
-        - Person::DEMOGRAPHIC_TYPES.each do |type, value|
-          .form-group
-            = f.label type
-            = f.select type, value, { include_blank: true }, { class: 'form-control' }
+      %p= render :partial => 'shared/demographics', :locals => {:f => f}
 
   .row.col-md-12.form-submit
     %button.pull-right.btn.btn-success{:type => "submit"} Save

--- a/app/views/admin/people/show.html.haml
+++ b/app/views/admin/people/show.html.haml
@@ -7,7 +7,7 @@
       = person.email
     %p
       - if person.demographics
-        - Person::DEMOGRAPHIC_TYPES.each do |type, value|
+        - Person::DEMOGRAPHICS.each do |type|
           %p
             = "#{type}:"
             = person.demographics[type.to_s]

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -56,10 +56,7 @@
         and will be
         %strong hidden
         from the review committee.
-        - Person::DEMOGRAPHIC_TYPES.each do |type, value|
-          .form-group
-            = f.label demographic_label(type)
-            = f.select type, value, { include_blank: true }, { class: 'form-control' }
+        = render :partial => 'shared/demographics', :locals => {:f => f}
 
   .row.col-md-12.form-submit
     %button.pull-right.btn.btn-success{:type => "submit"} Save

--- a/app/views/shared/_demographics.html.haml
+++ b/app/views/shared/_demographics.html.haml
@@ -1,0 +1,10 @@
+.form-group
+  = f.label demographic_label(:gender)
+  = f.text_field :gender, class: 'form-control', placeholder: 'Your gender identity'
+.form-group
+  = f.label demographic_label(:ethnicity)
+  = f.text_field :ethnicity, class: 'form-control', placeholder: 'Your ethnicity'
+- Person::DEMOGRAPHIC_TYPES.each do |type, value|
+  .form-group
+    = f.label demographic_label(type)
+    = f.select type, value, { include_blank: true }, { class: 'form-control' }

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 def select_demographics(args)
-  select(args[:gender], from: 'person[gender]')
-  select(args[:ethnicity], from: 'person[ethnicity]')
+  fill_in 'person[gender]',    with: args[:gender]
+  fill_in 'person[ethnicity]', with: args[:ethnicity]
+
   select(args[:country], from: 'person[country]')
 end
 


### PR DESCRIPTION
I'm wary of forcing people to use a specific set of results for both gender and ethnicity (though this is a relatively recent awareness, the credit really goes to @cczona and @megahbite). This patch changes both of those fields to text inputs instead of selects - people can describe themselves as they see fit, instead of feeling obliged to fit into a specific box (or the fallback of an 'Other' option).

Further context here: http://www.slideshare.net/cczona/schemas-for-the-real-world-rubyconf-au-201302
