### PR TITLE
Silencing FactoryGirl's tranient warning

### DIFF
--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
     end
 
     factory :organizer, traits: [ :organizer ] do
-      ignore do
+      transient do
         event { build(:event) }
       end
 
@@ -34,7 +34,7 @@ FactoryGirl.define do
     end
 
     factory :reviewer, traits: [ :reviewer ] do
-      ignore do
+      transient do
         event { build(:event) }
       end
 


### PR DESCRIPTION
This PR silences FactoryGirl's transient warning:

``` bash
DEPRECATION WARNING: `#ignore` is deprecated and will be removed in 5.0. Please use `#transient`
instead. (called from block (3 levels) in <top (required)> at /Users/adomokos/Programming/Rails/oss/cfp-
app/spec/factories/people.rb:37)
```
