### PR TITLE
h1 proposals should span entire block

### DIFF
--- a/app/assets/stylesheets/proposal.css.scss
+++ b/app/assets/stylesheets/proposal.css.scss
@@ -5,9 +5,6 @@
     display: inline;
   }
 
-  h1 {
-    float: left;
-  }
   span {
     &.status {
       float: right;
@@ -145,4 +142,3 @@ span.disabled-state {
   }
   dd { margin-left: 150px; }
 }
-


### PR DESCRIPTION
Previously if you have a short header, you get this:

<img src="https://api.monosnap.com/image/download?id=5TDG0LakPJZF1gzgxAdJj840aXs47I" />

This change makes the header span the entire block:

<img src="https://api.monosnap.com/image/download?id=yqkqp0A6baHHV4s0vUzLNiEPunJSe7" />

Another alternative would be to add right margin for h1 headers.