### PR TITLE
Fix DataTables Error When Adding New Sessions

### DIFF
--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -24,7 +24,7 @@ class SessionDecorator < Draper::Decorator
 
   def row_data(buttons: false)
     row = [ object.conference_day, start_time, end_time, linked_title,
-      presenter, room_name, track_name ]
+      presenter, room_name, track_name, session_id ]
 
     row << session_buttons if buttons
     row

--- a/app/views/organizer/sessions/_sessions.html.haml
+++ b/app/views/organizer/sessions/_sessions.html.haml
@@ -53,7 +53,6 @@
       %tr{ id: "session_#{session.id}" }
         - session.row_data.each do |cell|
           %td= cell
-        %td= session.id
         %td.actions
           = session.session_buttons
 #session-edit-dialog.modal.fade


### PR DESCRIPTION
DataTables was throwing an error because the row data being provided for the newly added session was missing the ID column. The fix was to add the session id to the SessionDecorator#row_data method.