### PR TITLE
Show bullets for ul elements created from markdown.

### DIFF
--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -196,6 +196,13 @@ h3.tags {
   }
 }
 
+// Markdown display
+.markdown {
+  ul {
+    list-style-type: disc;
+  }
+}
+
 
 //datepicker
 .ui-datepicker {

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -7,7 +7,8 @@
     .share.pull-right= event.tweet_button
   .col-md-8
     - if event.past_open? || event.open?
-      = markdown(event.guidelines)
+      .markdown
+        = markdown(event.guidelines)
     - elsif event.closes_at?
       %p
         Closed at

--- a/app/views/proposals/_comments.html.haml
+++ b/app/views/proposals/_comments.html.haml
@@ -2,7 +2,7 @@
   None
 
 - comments.order(:created_at).each do |comment|
-  .comment{ class: choose_class_for(comment) }
+  .comment.markdown{ class: choose_class_for(comment) }
     =markdown(comment.body)
 
     - if comment.person.present?

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -1,13 +1,13 @@
 %h3 Abstract
-%div{ data: { 'field-id' => 'proposal_abstract' } }
+.markdown{ data: { 'field-id' => 'proposal_abstract' } }
   = proposal.abstract
 
 %h3 Details
-%div{ data: { 'field-id' => 'proposal_details' } }
+.markdown{ data: { 'field-id' => 'proposal_details' } }
   = proposal.details
 
 %h3 Pitch
-%div{ data: { 'field-id' => 'proposal_pitch' } }
+.markdown{ data: { 'field-id' => 'proposal_pitch' } }
   =proposal.pitch
 
   - if proposal.custom_fields.any?


### PR DESCRIPTION
Hi! Rustcamp is using this app to do its CFP process, and the lack of bullets displaying in the rendered markdown was getting to me, so I fixed it! :sparkling_heart: 

It's hard to read ul elements when the list-style-type is none, and I expected markdown-enabled input fields to create bulleted lists in the generated output.

I added a class `markdown` around places in the interface that render entered markdown and set the ul list-style-type to disc within those elements.

### Event Guidelines 
#### Before:
![guidelines-before](https://cloud.githubusercontent.com/assets/193874/8269299/800c9d84-1771-11e5-94b1-fe12be25543c.png)
#### After:
![guidelines-after](https://cloud.githubusercontent.com/assets/193874/8269302/860b7534-1771-11e5-8165-980a71ba650e.png)

### Proposal preview
#### Before:
![preview-before](https://cloud.githubusercontent.com/assets/193874/8269304/904910c4-1771-11e5-8ad3-b6b74db537d7.png)
#### After:
![preview-after](https://cloud.githubusercontent.com/assets/193874/8269305/98d8cf4a-1771-11e5-94a4-dca8f6a248c9.png)

### Reviewing
#### Before:
![review-before](https://cloud.githubusercontent.com/assets/193874/8269308/a432dbd8-1771-11e5-843a-87be2a854b25.png)
#### After:
![review-after](https://cloud.githubusercontent.com/assets/193874/8269309/a96ca066-1771-11e5-8f3f-4d16138ea7a8.png)

Thank you!!! :heart: :heart_decoration: :heart: :heart_decoration: 