### PR TITLE
Fix for Admin::PeopleController#update: local var to instance var;

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -21,7 +21,7 @@ class Admin::PeopleController < Admin::ApplicationController
     if @person.update(person_params)
       redirect_to admin_people_path, flash: { info: "#{@person.name} was successfully updated." }
     else
-      render :edit, locals: { person: person }
+      render :edit, locals: { person: @person }
     end
   end
 


### PR DESCRIPTION
If administrator update of a Person fails, an error is thrown due to access of local var `person` (which should be instance var `@person`). This PR has the fix.