### PR TITLE
#8: withdrawn proposals are not shown to reviewers

### DIFF
--- a/app/controllers/reviewer/proposals_controller.rb
+++ b/app/controllers/reviewer/proposals_controller.rb
@@ -7,7 +7,7 @@ class Reviewer::ProposalsController < Reviewer::ApplicationController
   def index
     proposal_ids = current_user.proposals.pluck(:id)
 
-    proposals = @event.proposals.includes(:proposal_taggings, :review_taggings,
+    proposals = @event.proposals.not_withdrawn.includes(:proposal_taggings, :review_taggings,
       :ratings, :internal_comments, :public_comments).where.not(id: proposal_ids)
 
     proposals.to_a.sort_by! { |p| [ p.ratings.present? ? 1 : 0, p.created_at ] }

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -3,7 +3,7 @@ class EventDecorator < ApplicationDecorator
 
   def proposals_rated_message
     rated_count = h.current_user.ratings.for_event(object).size
-    proposals_count = object.proposals.size
+    proposals_count = object.proposals.not_withdrawn.size
 
     message = "#{rated_count}/#{proposals_count}"
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,7 @@ class Event < ActiveRecord::Base
 
   scope :recent, -> { order('name ASC') }
   scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.current).order('closes_at ASC') }
+  scope :not_withdrawn, -> {where.not(event.proposal(state: WITHDRAWN))}
 
   validates :name, :contact_email, presence: true
   validates :slug, presence: true, uniqueness: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,7 +23,6 @@ class Event < ActiveRecord::Base
 
   scope :recent, -> { order('name ASC') }
   scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.current).order('closes_at ASC') }
-  scope :not_withdrawn, -> {where.not(event.proposal(state: WITHDRAWN))}
 
   validates :name, :contact_email, presence: true
   validates :slug, presence: true, uniqueness: true

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -40,6 +40,7 @@ class Proposal < ActiveRecord::Base
   scope :unrated, -> { where('id NOT IN ( SELECT proposal_id FROM ratings )') }
   scope :rated, -> { where('id IN ( SELECT proposal_id FROM ratings )') }
   scope :scheduled, -> { joins(:session) }
+  scope :not_withdrawn, -> {where.not(state: WITHDRAWN)}
   scope :waitlisted, -> { where(state: WAITLISTED) }
   scope :available, -> do
     includes(:session).where(sessions: {proposal_id: nil}, state: ACCEPTED).order(:title)

--- a/app/views/reviewer/proposals/index.html.haml
+++ b/app/views/reviewer/proposals/index.html.haml
@@ -10,7 +10,7 @@
           %dt Proposals Rated:
           %dd= event.proposals_rated_message
           %dt Unrated Proposals:
-          %dd= event.proposals.unrated.count
+          %dd= event.proposals.unrated.not_withdrawn.count
   .row
     .col-md-10
       %small <em>Hint:</em> Hold <kbd>shift</kbd> and click sorting arrows to sort by multiple columns


### PR DESCRIPTION
Proposals that have been withdrawn should not be part of the total number of proposals to be rated

On reviewer's page, withdrawn proposals should be removed. Organizers can see all proposals, including withdrawn.

@mgarriott @Kel4545 when you get a chance, can you review? thanks!