### PR TITLE
#10 Guidelines should be visible

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,6 +28,7 @@ class Event < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
 
   before_validation :generate_slug
+  before_save :update_closes_at_if_manually_closed
 
 
   def valid_proposal_tags
@@ -121,6 +122,13 @@ class Event < ActiveRecord::Base
 
   def conference_date(conference_day)
     start_date + (conference_day - 1).days
+  end
+
+  private
+  def update_closes_at_if_manually_closed
+    if changes.key?(:state) && changes[:state] == ['open', 'closed']
+      self.closes_at = DateTime.now
+    end
   end
 end
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -6,13 +6,11 @@
   .col-md-1
     .share.pull-right= event.tweet_button
   .col-md-8
-    - if event.past_open? || event.open?
-      .markdown
-        = markdown(event.guidelines)
-    - elsif event.closes_at?
-      %p
-        Closed at
+    .markdown
+      - if event.closed?
+        Closed on
         %strong= event.closes_at(:long_with_zone)
+      = markdown(event.guidelines)
   .col-md-4
     - if event.open?
       %p= link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary'


### PR DESCRIPTION
Guidelines should be visible regardless of if the event is open or closed

@mgarriott can you take a look when you have a chance? thanks!