### PR TITLE
Save oauth account_name for fallback service lookups

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,14 +6,15 @@ end
 #
 # Table name: services
 #
-#  id         :integer          not null, primary key
-#  provider   :string(255)
-#  uid        :string(255)
-#  person_id  :integer
-#  uname      :string(255)
-#  uemail     :string(255)
-#  created_at :datetime
-#  updated_at :datetime
+#  id           :integer          not null, primary key
+#  provider     :string(255)
+#  uid          :string(255)
+#  person_id    :integer
+#  uname        :string(255)
+#  uemail       :string(255)
+#  created_at   :datetime
+#  updated_at   :datetime
+#  account_name :string(255)
 #
 # Indexes
 #

--- a/db/migrate/20151217214608_add_account_name_to_service.rb
+++ b/db/migrate/20151217214608_add_account_name_to_service.rb
@@ -1,0 +1,5 @@
+class AddAccountNameToService < ActiveRecord::Migration
+  def change
+    add_column :services, :account_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150604225912) do
+ActiveRecord::Schema.define(version: 20151217214608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,6 +165,7 @@ ActiveRecord::Schema.define(version: 20150604225912) do
     t.string   "uemail"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "account_name"
   end
 
   add_index "services", ["person_id"], name: "index_services_on_person_id", using: :btree


### PR DESCRIPTION
Several users have complained that they cannot log into their accounts after an unspecified elapsed time. We believe this is as a result of Twitter and Github returning different user ids for the account when using the oAuth authentication.

This change adds an account_name field to the Service model in which we will now save the returned Github account name or Twitter handle. In the event that looking up a service by UID fails, we will then try to look up the service by account name instead. We'll also now update a found service with any new information.

Unrelated, but still in this change, I fixed a failing spec app/models/person_spec:251. This spec was failing due to a previous change that added a validation to the Participant model.