### PR TITLE
Fix deprecation warning and update specs

### DIFF
--- a/app/controllers/organizer/proposals_controller.rb
+++ b/app/controllers/organizer/proposals_controller.rb
@@ -43,7 +43,7 @@ class Organizer::ProposalsController < Organizer::ApplicationController
       end
     end
 
-    current_user.notifications.mark_as_read_for_proposal(reviewer_event_proposal_path(@event, @proposal))
+    current_user.notifications.mark_as_read_for_proposal(reviewer_event_proposal_url(@event, @proposal))
     render locals: {
              speakers: @proposal.speakers.decorate,
              other_proposals: Organizer::ProposalsDecorator.decorate(other_proposals),

--- a/app/controllers/reviewer/proposals_controller.rb
+++ b/app/controllers/reviewer/proposals_controller.rb
@@ -22,7 +22,7 @@ class Reviewer::ProposalsController < Reviewer::ApplicationController
   def show
     set_title(@proposal.title)
     rating = current_user.rating_for(@proposal)
-    current_user.notifications.mark_as_read_for_proposal(request.path)
+    current_user.notifications.mark_as_read_for_proposal(request.url)
     render locals: {
       rating: rating
     }

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -2,16 +2,13 @@ class PersonDecorator < ApplicationDecorator
   delegate_all
 
   def proposal_path(proposal)
-    # it seems like calling any path helper throws a deprecation like the one below:
-    # DEPRECATION WARNING: The method `reviewer_event_proposal_path` cannot be used here as a full URL is required. Use `reviewer_event_proposal_url` instead. (called from proposal_path at /app/decorators/person_decorator.rb:7)
-
     event = proposal.event
     if object.organizer_for_event?(event)
-      h.reviewer_event_proposal_path(event, proposal)
+      h.reviewer_event_proposal_url(event, proposal)
     elsif object.reviewer_for_event?(event)
-      h.reviewer_event_proposal_path(event, proposal)
+      h.reviewer_event_proposal_url(event, proposal)
     else
-      h.proposal_path(event.slug, proposal)
+      h.proposal_url(event.slug, proposal)
     end
   end
 end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -6,14 +6,14 @@ describe PersonDecorator do
       speaker = create(:speaker)
       proposal = create(:proposal, speakers: [ speaker ])
       expect(speaker.person.decorate.proposal_path(proposal)).to(
-        eq(h.proposal_path(proposal.event.slug, proposal)))
+        eq(h.proposal_url(proposal.event.slug, proposal)))
     end
 
     it "returns the path for a reviewer" do
       reviewer = create(:person, :reviewer)
       proposal = create(:proposal)
       expect(reviewer.decorate.proposal_path(proposal)).to(
-        eq(h.reviewer_event_proposal_path(proposal.event, proposal)))
+        eq(h.reviewer_event_proposal_url(proposal.event, proposal)))
     end
   end
 end


### PR DESCRIPTION
Whenever I run specs, I see this deprecation warning:

```
DEPRECATION WARNING: The method `proposal_path` cannot be used here as a full URL is required. Use `proposal_url` instead. (called from proposal_path at /Users/winston/workspace/cfp-app/app/decorators/person_decorator.rb:14)
```

Also, I see a comment in `app/decorators/person_decorator.rb` and I am not sure if it's meant to be a signal for "Don't fix" or "TODO". Hence I went ahead to fix to the deprecation warning by updating `*_path` to `*_url` in `app/decorators/person_decorator.rb`.

This however broke some specs, and so I fixed those specs as well to use `*_url`. 

Is there some history to this? Or would this change be acceptable? Thank you! 

