### PR TITLE
16 - Make event link and dates clear to speakers

### DIFF
--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -208,3 +208,9 @@ h3.tags {
 .ui-datepicker {
   z-index: 10000 !important;
 }
+
+// spacing
+
+.margin-top {
+  margin-top: 1em;
+}

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -1,22 +1,29 @@
 #proposal
   .row
     .col-md-8
+      %h3
+        = link_to proposal.event.name, event_path(slug: proposal.event.slug)
+        = ", "
+        = proposal.event.start_date.to_s(:month_day_year)
       %h1
         = proposal.title
     .col-md-4
       - if proposal.has_speaker?(current_user)
         .toolbox.pull-right
           .clearfix
-          - unless proposal.withdrawn? || proposal.accepted? || proposal.confirmed?
-            = link_to edit_proposal_path(slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
-              %span.glyphicon.glyphicon-edit
-              Edit
-            -if proposal.has_reviewer_activity?
-              = proposal.withdraw_button
-            -else
-              = link_to proposal_path, method: :delete, data: {confirm: 'This will delete your talk. Are you sure you want to do this? It can not be undone.'}, class: 'btn btn-warning', id: 'delete' do
-                %span.glyphicon.glyphicon-exclamation-sign
-                Delete Proposal
+            - unless proposal.withdrawn? || proposal.accepted? || proposal.confirmed?
+              = link_to edit_proposal_path(slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
+                %span.glyphicon.glyphicon-edit
+                Edit
+              -if proposal.has_reviewer_activity?
+                = proposal.withdraw_button
+              -else
+                = link_to proposal_path, method: :delete, data: {confirm: 'This will delete your talk. Are you sure you want to do this? It can not be undone.'}, class: 'btn btn-warning', id: 'delete' do
+                  %span.glyphicon.glyphicon-exclamation-sign
+                  Delete Proposal
+          %h5.margin-top
+            CFP closes
+            = event.closes_at(:month_day_year)
   .row
     .col-md-12.tags= proposal.tags
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 20151217214608) do
     t.integer  "person_id"
     t.integer  "parent_id"
     t.text     "body"
-    t.string   "type"
+    t.string   "type",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -31,11 +31,11 @@ ActiveRecord::Schema.define(version: 20151217214608) do
   add_index "comments", ["proposal_id"], name: "index_comments_on_proposal_id", using: :btree
 
   create_table "events", force: :cascade do |t|
-    t.string   "name"
-    t.string   "slug"
-    t.string   "url"
-    t.string   "contact_email"
-    t.string   "state",                       default: "closed"
+    t.string   "name",                        limit: 255
+    t.string   "slug",                        limit: 255
+    t.string   "url",                         limit: 255
+    t.string   "contact_email",               limit: 255
+    t.string   "state",                       limit: 255, default: "closed"
     t.datetime "opens_at"
     t.datetime "closes_at"
     t.datetime "start_date"
@@ -44,10 +44,10 @@ ActiveRecord::Schema.define(version: 20151217214608) do
     t.text     "review_tags"
     t.text     "guidelines"
     t.text     "policies"
-    t.hstore   "speaker_notification_emails", default: {"accept"=>"", "reject"=>"", "waitlist"=>""}
+    t.hstore   "speaker_notification_emails",             default: {"accept"=>"", "reject"=>"", "waitlist"=>""}
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "archived",                    default: false
+    t.boolean  "archived",                                default: false
     t.text     "custom_fields"
   end
 
@@ -56,9 +56,9 @@ ActiveRecord::Schema.define(version: 20151217214608) do
   create_table "invitations", force: :cascade do |t|
     t.integer  "proposal_id"
     t.integer  "person_id"
-    t.string   "email"
-    t.string   "state",       default: "pending"
-    t.string   "slug"
+    t.string   "email",       limit: 255
+    t.string   "state",       limit: 255, default: "pending"
+    t.string   "slug",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -70,21 +70,21 @@ ActiveRecord::Schema.define(version: 20151217214608) do
 
   create_table "notifications", force: :cascade do |t|
     t.integer  "person_id"
-    t.string   "message"
-    t.datetime "read_at"
-    t.string   "target_path"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "message",     limit: 255
+    t.datetime "read_at"
+    t.string   "target_path", limit: 255
   end
 
   add_index "notifications", ["person_id"], name: "index_notifications_on_person_id", using: :btree
 
   create_table "participant_invitations", force: :cascade do |t|
-    t.string   "email"
-    t.string   "state"
-    t.string   "slug"
-    t.string   "role"
-    t.string   "token"
+    t.string   "email",      limit: 255
+    t.string   "state",      limit: 255
+    t.string   "slug",       limit: 255
+    t.string   "role",       limit: 255
+    t.string   "token",      limit: 255
     t.integer  "event_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -93,38 +93,38 @@ ActiveRecord::Schema.define(version: 20151217214608) do
   create_table "participants", force: :cascade do |t|
     t.integer  "event_id"
     t.integer  "person_id"
-    t.string   "role"
+    t.string   "role",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "notifications", default: true
+    t.boolean  "notifications",             default: true
   end
 
   add_index "participants", ["event_id"], name: "index_participants_on_event_id", using: :btree
   add_index "participants", ["person_id"], name: "index_participants_on_person_id", using: :btree
 
   create_table "people", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
+    t.string   "name",         limit: 255
+    t.string   "email",        limit: 255
     t.text     "bio"
     t.hstore   "demographics"
-    t.boolean  "admin",        default: false
+    t.boolean  "admin",                    default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "proposals", force: :cascade do |t|
     t.integer  "event_id"
-    t.string   "state",                 default: "submitted"
-    t.string   "uuid"
-    t.string   "title"
+    t.string   "state",                 limit: 255, default: "submitted"
+    t.string   "uuid",                  limit: 255
+    t.string   "title",                 limit: 255
     t.text     "abstract"
     t.text     "details"
     t.text     "pitch"
-    t.text     "last_change"
-    t.text     "confirmation_notes"
     t.datetime "confirmed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "last_change"
+    t.text     "confirmation_notes"
     t.datetime "updated_by_speaker_at"
     t.text     "proposal_data"
   end
@@ -144,10 +144,10 @@ ActiveRecord::Schema.define(version: 20151217214608) do
   add_index "ratings", ["proposal_id"], name: "index_ratings_on_proposal_id", using: :btree
 
   create_table "rooms", force: :cascade do |t|
-    t.string   "name"
-    t.string   "room_number"
-    t.string   "level"
-    t.string   "address"
+    t.string   "name",          limit: 255
+    t.string   "room_number",   limit: 255
+    t.string   "level",         limit: 255
+    t.string   "address",       limit: 255
     t.integer  "capacity"
     t.integer  "event_id"
     t.datetime "created_at"
@@ -158,14 +158,14 @@ ActiveRecord::Schema.define(version: 20151217214608) do
   add_index "rooms", ["event_id"], name: "index_rooms_on_event_id", using: :btree
 
   create_table "services", force: :cascade do |t|
-    t.string   "provider"
-    t.string   "uid"
+    t.string   "provider",     limit: 255
+    t.string   "uid",          limit: 255
     t.integer  "person_id"
-    t.string   "uname"
-    t.string   "uemail"
+    t.string   "uname",        limit: 255
+    t.string   "uemail",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "account_name"
+    t.string   "account_name", limit: 255
   end
 
   add_index "services", ["person_id"], name: "index_services_on_person_id", using: :btree
@@ -200,8 +200,8 @@ ActiveRecord::Schema.define(version: 20151217214608) do
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "proposal_id"
-    t.string   "tag"
-    t.boolean  "internal",    default: false
+    t.string   "tag",         limit: 255
+    t.boolean  "internal",                default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
Make finding the link to the event along with its date very obvious to speakers

Resolves this issue: "It's very hard to find the link to the event itself or the date of the event anywhere. I was confirming my proposal and had hard time remembering when the actual NYC.rb was"