### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+rvm:
+  - 2.3.0
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
+addons:
+  apt:
+    sources:
+      - ubuntu-sdk-team
+    packages:
+      - libqt5webkit5-dev
+      - qtdeclarative5-dev
+bundler_args: --jobs=3 --retry=3 --without development
+script: xvfb-run bundle exec rake
+before_script:
+  - psql -c 'create database cfp_app_test;' -U postgres


### PR DESCRIPTION
This PR sets up the repo for travis-ci to run. Example of running the fork at https://github.com/reddotrubyconf/cfp-app: https://travis-ci.org/reddotrubyconf/cfp-app/builds/101747796.

Admin of the repo will still have to enable the repo at https://travis-ci.org/ though.

Thank you!