### PR TITLE
Fixed broken next proposal link in views/reviewer/proposals/show

### DIFF
--- a/app/views/reviewer/proposals/show.html.haml
+++ b/app/views/reviewer/proposals/show.html.haml
@@ -36,7 +36,7 @@
       %h3 Tags
       = render partial: 'shared/proposals/tags_form',
         locals: { event: event, proposal: proposal }
-      =link_to('#', class: "btn btn-primary") do
+      =link_to reviewer_event_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary" do
         Next Proposal &raquo;
 
       .internal-comments{ style: proposal.internal_comments_style }


### PR DESCRIPTION
The link on this page needed to be hooked into the script that's defined in <a href='https://github.com/rubycentral/cfp-app/blob/master/app/assets/javascripts/organizer/proposals.js'>javascripts/organizer/proposals.js</a>  The fix is very similar to what already exists in <a href='https://github.com/rubycentral/cfp-app/blob/master/app/views/organizer/proposals/show.html.haml'>views/organizier/proposals/show:14-15</a>

Maybe the script should be moved somewhere else, if it's shared in across two different views?