### PR TITLE
remove errant variable in proposal.rb

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -202,7 +202,6 @@ class Proposal < ActiveRecord::Base
       update_tags(proposal_taggings, @tags, false)
     end
   end
-  @dont_touch_updated_by_speaker_at
 
   def save_review_tags
     if @review_tags


### PR DESCRIPTION
I noticed an unassigned ```@dont_touch_updated_by_speaker_at``` variable at line 205.  It doesn't appear to be doing anything.