### PR TITLE
Use full HTTPS URL for git dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'pg'
 
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'jquery-datatables-rails', github: "rweng/jquery-datatables-rails"
+gem 'jquery-datatables-rails', git: "https://github.com/rweng/jquery-datatables-rails"
 gem 'uglifier', '>= 1.3.0'
 gem 'sass-rails', '~> 4.0.1'
 gem 'haml', '~> 4.0.4'


### PR DESCRIPTION
Bundler recommends to use fully qualified dependencies
for security over all versions.

`:github` dependencies _might_ resolve to an unsecured source.
See http://bundler.io/git.html#security