### PR TITLE
Fix heroku deploy issue

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
# Purpose

Fix deploy to heroku issue.
Heroku refuse to deploy if asset compile is turned on in production due to CVE-2018-3760.
https://blog.heroku.com/rails-asset-pipeline-vulnerability 

# Changes
- turn off asset compile in production