### PR TITLE
Accessibility: remove proposal comment titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,11 +96,11 @@ project:
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/ruby-central/cfp-app
+   git clone https://github.com/rubycentral/cfp-app.git
    # Navigate to the newly cloned directory
    cd cfp-app
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/ruby-central/cfp-app
+   git remote add upstream https://github.com/rubycentral/cfp-app.git
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream:

--- a/app/views/proposals/_comments.html.haml
+++ b/app/views/proposals/_comments.html.haml
@@ -3,7 +3,7 @@
     %li.comment.markdown{ class: choose_class_for(comment) }
       .message_wrap
         - if comment.user.present?
-          .info{ title: comment.created_at.to_s }
+          .info
             %p.name
               = commenter_name(comment)
             %span.time #{comment.created_at.to_s(:day_at_time)}


### PR DESCRIPTION
## Problem

When reading a proposal's comments with a screen reader, it reads out
the entire timestamp of a comment, like `2019-01-02 20:33:56 -0800`.
When read out loud, this takes a long time, is disruptive to the reading
experience, and sounds a bit silly.

Further, this timestamp is nowhere on the page and doesn't seem to serve
a purpose.

## Solution

Instead, this PR removes the `title` field on each proposal comment.
This way, when entering the comment section, a user hears the "X
[Public/Internal] Comments" header, then is able to dive directly into
each comment itself. This content flow is much smoother, making for a
better user experience.

## Notes

I also fixed some broken code snippets in `CONTRIBUTING.md`. The git
remotes did not point to git repositories, and the org name was incorrectly
listed as "ruby-central" instead of "rubycentral".