### PR TITLE
Fix error with saving speaker email templates

### DIFF
--- a/app/controllers/staff/events_controller.rb
+++ b/app/controllers/staff/events_controller.rb
@@ -21,8 +21,8 @@ class Staff::EventsController < Staff::ApplicationController
     if @event.update(params.require(:event).permit(:accept, :reject, :waitlist))
       redirect_to event_staff_speaker_email_notifications_path
     else
-      flash[:danger] = "There was a problem saving your email templates; please review the form for issues and try again."
-      render :speaker_email_notifications
+      flash[:danger] = "There was a problem saving your email templates. #{@event.errors.full_messages.to_sentence}"
+      render :speaker_emails
     end
   end
 
@@ -31,8 +31,8 @@ class Staff::EventsController < Staff::ApplicationController
     if @event.remove_speaker_email_template(params[:type].to_sym)
       redirect_to event_staff_speaker_email_notifications_path
     else
-      flash[:danger] = "There was a problem saving your email templates; please review the form for issues and try again."
-      render :speaker_email_notifications
+      flash[:danger] = "There was a problem saving your email templates. #{@event.errors.full_messages.to_sentence}"
+      render :speaker_emails
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -165,7 +165,7 @@ class Event < ApplicationRecord
     missing_items << "Event must have a start date" unless start_date
     missing_items << "Event must have an end date" unless end_date
     missing_items << "Event must have a contact email" unless contact_email.present?
-    missing_items << "Event must have a CFP closes at date set for a future date" unless closes_at && (closes_at > Time.current)
+    # missing_items << "Event must have a CFP closes at date set for a future date" unless closes_at && (closes_at > Time.current)
     missing_items << "Event must have at least one public session format" unless public_session_formats.present?
     missing_items << "Event must have guidelines" unless guidelines.present?
 


### PR DESCRIPTION
The issue happens after a CFP has closed and the organizer wants to save or update a speaker email template.  We're not sure how appropriate the validation check on having a closes_at date that is in the future.  It makes sense when you're initially creating an event but makes zero sense after it's been closed.  I decided to just remove the check altogether.  I'll just trust organizers to set closes_at dates appropriately.

This error also exposed the fact that our render on errors never worked due to an incorrect template path.