### PR TITLE
Bump character limit to match new behavior

### DIFF
--- a/app/helpers/proposal_helper.rb
+++ b/app/helpers/proposal_helper.rb
@@ -33,7 +33,7 @@ module ProposalHelper
   end
 
   def abstract_tooltip
-    "A concise, engaging description for the public program. Limited to 600 characters."
+    "A concise, engaging description for the public program. Limited to 1,000 characters."
   end
 
   def details_tooltip


### PR DESCRIPTION
This PR updates the user tooltip to match the new character limit introduced in 82a6fdaaae3a40654fce8476e812e25b766cdb75.