### PR TITLE
[New feature] Link to add/edit Gravatar profile icon in Edit Profile view

### DIFF
--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -49,6 +49,16 @@
             = f.label :password_confirmation
             = f.password_field :password_confirmation, class: 'form-control', placeholder: 'Confirm password'
 
+    %fieldset.col-md-6
+      .widget
+        .widget-header
+          %i.fa.fa-lock
+          %h3 Profile Icon Image
+        .widget-content
+          %p
+            Add or change your profile icon image by visiting
+            = link_to('Gravatar', 'https://en.gravatar.com/connect/', target: "_blank")
+
           - if current_user.provider.present?
             .service
               %button.btn.btn-default.disabled{class: "btn-#{current_user.provider.downcase}-alt"}


### PR DESCRIPTION
Currently, there is no intuitive way from the CFPApp itself to know where the profile icon is obtained from, and how to either add or change it. People for a variety of reasons may want to change their profile image on CFPApp from the time they first opened an account, and as it stands now, there is no clear path to do that easily. 

In this pull request, a new section is added to the `Edit Profile` view, which provides a link to either add or edit one's profile image hosted on Gravatar, which is where CFPApp receives it from. This new feature is an enhancement of the user experience.