### PR TITLE
Redo proposal abstract length validation

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -19,11 +19,7 @@ class Proposal < ApplicationRecord
   belongs_to :track
 
   validates :title, :abstract, :session_format, presence: true
-
-  # This used to be 600, but it's so confusing for users that the browser
-  # uses \r\n for newlines and they're over the 600 limit because of
-  # bytes they can't see. So we give them a bit of tolerance.
-  validates :abstract, length: {maximum: 1000}
+  validate :abstract_length
   validates :title, length: {maximum: 60}
   validates_inclusion_of :state, in: valid_states, allow_nil: true, message: "'%{value}' not a valid state."
   validates_inclusion_of :state, in: FINAL_STATES, allow_nil: false, message: "'%{value}' not a confirmable state.",
@@ -254,6 +250,11 @@ class Proposal < ApplicationRecord
   end
 
   private
+
+  def abstract_length
+    return unless abstract.gsub(/\r/, '').gsub(/\n/, '').length > 600
+    errors.add(:abstract, "is too long (maximum is 600 characters)")
+  end
 
   def save_tags
     if @tags

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -24,31 +24,6 @@ describe Proposal do
     end
   end
 
-  # describe "scope :available" do
-  #   it "shows a previously assigned but removed proposal as available" do
-  #     proposal = create(:proposal, state: ACCEPTED)
-  #     conf_session = create(:time_slot, proposal: proposal, event: proposal.event)
-  #
-  #     expect {
-  #       conf_session.destroy
-  #     }.to change{Proposal.available.count}.by(1)
-  #   end
-  #
-  #   it "only shows accepted proposals" do
-  #     create(:proposal, state: WAITLISTED)
-  #     proposal = create(:proposal, state: ACCEPTED)
-  #
-  #     expect(Proposal.available).to match_array([ proposal ])
-  #   end
-  #
-  #   it "sorts proposals by talk title" do
-  #     zebra = create(:proposal, title: 'Zebra', state: ACCEPTED)
-  #     theta = create(:proposal, title: 'Theta', state: ACCEPTED)
-  #     alpha = create(:proposal, title: 'Alpha', state: ACCEPTED)
-  #     expect(Proposal.available).to eq([ alpha, theta, zebra ])
-  #   end
-  # end
-
   describe 'scope :in_track' do
     let(:track1) { create :track, name: 'Track 1' }
     let(:track1_proposals) { create_list :proposal, 3, track: track1 }
@@ -84,9 +59,9 @@ describe Proposal do
       expect{proposal.save}.to change{proposal.uuid}.from(nil).to('greendalec')
     end
 
-    it "limits abstracts to 1000 characters or less" do
-      expect(build(:proposal, abstract: "S" * 999)).to be_valid
-      expect(build(:proposal, abstract: "S" * 1006)).not_to be_valid
+    it "limits abstracts to 600 characters or less" do
+      expect(build(:proposal, abstract: "S" * 600)).to be_valid
+      expect(build(:proposal, abstract: "S" * 601)).not_to be_valid
     end
   end
 


### PR DESCRIPTION
The abstract length was originally 600 characters. Carriage return
characters would typically be included in the standard length
validation, so the limit was increased to 1000. This commit creates a
custom validation to strip out the carriage return characters and count
the resulting string length. If _THAT_ is greater than 600 characters
then there is an error.