### PR TITLE
Allow updating tags after proposal is finalized

### DIFF
--- a/app/helpers/staff_helper.rb
+++ b/app/helpers/staff_helper.rb
@@ -16,6 +16,7 @@ module StaffHelper
     (proposal.finalized? && (!proposal.ratings.any? || !rating.persisted?)) || proposal.has_speaker?(current_user)
   end
 
+  # Deprecated - was used to disallow modifying speaker tags once a talk was finalized
   def allow_review?(proposal)
     (program_mode? || !proposal.has_speaker?(current_user)) && !proposal.finalized?
   end

--- a/app/views/shared/proposals/_tags_form.html.haml
+++ b/app/views/shared/proposals/_tags_form.html.haml
@@ -1,13 +1,12 @@
-- if allow_review?(proposal)
-  = form_for proposal, url: event_staff_proposal_path(event, proposal), html: {role: 'form', remote: true} do |f|
-    .form-group.col-sm-8.no-pad-left
-      .tag-list
-        #autocomplete-options
-          = (event.review_tags | proposal.review_tags)
-        = f.text_field :review_tags, { value: proposal.review_tags.join(','), tabindex: '-1' }
-        = program_tracker
-    .form-group.col-sm-4
-      %button.btn.btn-success.btn-sm(type="submit")
-        %span.glyphicon.glyphicon-ok
-      #cancel-tags-editing.btn.btn-danger.btn-sm
-        %span.glyphicon.glyphicon-remove
+= form_for proposal, url: event_staff_proposal_path(event, proposal), html: {role: 'form', remote: true} do |f|
+  .form-group.col-sm-8.no-pad-left
+    .tag-list
+      #autocomplete-options
+        = (event.review_tags | proposal.review_tags)
+      = f.text_field :review_tags, { value: proposal.review_tags.join(','), tabindex: '-1' }
+      = program_tracker
+  .form-group.col-sm-4
+    %button.btn.btn-success.btn-sm(type="submit")
+      %span.glyphicon.glyphicon-ok
+    #cancel-tags-editing.btn.btn-danger.btn-sm
+      %span.glyphicon.glyphicon-remove

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -83,8 +83,7 @@
                   #{proposal.review_tags_labels}
                 -else
                   %em None
-              - if allow_review?(proposal)
-                #edit-tags-icon.fa.fa-pencil
+              #edit-tags-icon.fa.fa-pencil
               #review-tags-form-wrapper
                 = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
             .proposal-meta-item.col-sm-3

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -76,10 +76,9 @@
                   #{proposal.review_tags_labels}
                 -else
                   %em None
-              - if allow_review?(proposal)
-                #edit-tags-icon.fa.fa-pencil
-            #review-tags-form-wrapper
-              = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
+              #edit-tags-icon.fa.fa-pencil
+              #review-tags-form-wrapper
+                = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
 
   .row
     .col-md-4


### PR DESCRIPTION
Tags can be a helpful way to organize talks into buckets as they are
being evaluated and accepted. They can also be useful for categorizing
talks when creating the schedule to make sure you have a good balance
across days and rooms. This allows tags to be updated after a talk has
been finalized. #146