### PR TITLE
Genericize ActionMailer settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ This will boot up using Foreman and allow the .env file to be read / set for use
     POSTGRES_USER (dev/test only)
     MAIL_HOST (production only - from host)
     MAIL_FROM (production only - from address)
+    SMTP_ADDRESS (production only - address of SMTP server, defaults to 'smtp.sendgrid.net')
+    SMTP_PORT (production only - port of SMTP server, defaults to 587)
+    SMTP_USERNAME (production only - SMTP account username, defaults to 'apikey' for use with SendGrid)
+    SMTP_PASSWORD (production only - SMTP account password, defaults to feching environment variable 'SENDGRID_API_KEY')
     SECRET_TOKEN (production only)
     GITHUB_KEY
     GITHUB_SECRET

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,9 +101,9 @@ Rails.application.configure do
     address: ENV.fetch('SMTP_ADDRESS', 'smtp.sendgrid.net'),
     port: ENV.fetch('SMTP_PORT', '587'),
     authentication: :plain,
-    user_name: "apikey",
-    password: ENV.fetch('SENDGRID_API_KEY', ""),
-    domain: 'heroku.com',
+    user_name: ENV.fetch('SMTP_USERNAME', 'apikey'),
+    password: ENV.fetch('SMTP_PASSWORD', ENV.fetch('SENDGRID_API_KEY', "")),
+    domain: ENV.fetch('SMTP_DOMAIN', 'heroku.com'),
     enable_starttls_auto: true
   }
 


### PR DESCRIPTION
The current ActionMailer setup in `production.rb` has several settings that assume one is deploying cfp-app with SendGrid. This PR generalizes those settings so that other SMTP providers could be used out of the box. The defaults are the existing SendGrid specific values so that existing installations can upgrade in place and not be impacted.

A few notes: 

- added documentation of these variables to `README.md'
- did NOT add these variables to `app.json` as the existing `SMTP_ADDRESS` and `SMTP_PORT` aren't listed there. I'm not sure if these values should be added or not.