### PR TITLE
Update ruby version in travis config, upgrade Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.7.2
+  - 2.7.4
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -555,4 +555,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.15
+   2.3.7

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The CFP App does not provide a public facing website for your conference, though
 ### Prerequisite Requirements
 
 * Ruby 2.7.4
-* Bundler (was installed with 2.1.4)
+* Bundler (was installed with 2.3.7)
 * PostgreSQL
 
 Make sure you have Ruby and Postgres installed in your environment.  Double check in the [Gemfile](../blob/master/Gemfile) for the exact supported version.  This is a Rails 6 app and uses bundler to install all required gems.  We are also making the assumption that you're familiar with how Rails apps are setup and deployed.  If this is not the case then you'll want to refer to documentation that will bridge any gaps in the instructions below.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The CFP App does not provide a public facing website for your conference, though
 
 ### Prerequisite Requirements
 
-* Ruby 2.7.2
+* Ruby 2.7.4
 * Bundler (was installed with 2.1.4)
 * PostgreSQL
 
@@ -93,7 +93,7 @@ There are five user roles in the CFP App. To log in as a user type in developmen
 
 ## Deployment on Heroku
 
-The app was written with a Heroku deployment stack in mind. You can easily deploy the application using the button below, or you can deploy it anywhere assuming you can run Ruby 2.7.2 and Rails 6.1.x with a PostgreSQL database and an SMTP listener.
+The app was written with a Heroku deployment stack in mind. You can easily deploy the application using the button below, or you can deploy it anywhere assuming you can run Ruby 2.7.4 and Rails 6.1.x with a PostgreSQL database and an SMTP listener.
 
 The Heroku stack will use the following free addons:
 


### PR DESCRIPTION
Several dependencies were updated from Ruby 2.7.2 to 2.7.4 in [this commit](https://github.com/rubycentral/cfp-app/commit/4e066d093df037b7954a6e3ca31fca425d6190b7) in PR https://github.com/rubycentral/cfp-app/pull/229, but the Ruby version in `.travis.yml` was missed. This PR updates it so the project runs on Travis-CI again!

(Also upgraded Bundler to the latest to fix a deprecation error message)