### PR TITLE
Schedule page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,12 @@ GIT
     mimemagic (0.3.5)
 
 GEM
-  remote: https://rubygems.org/
   remote: https://rails-assets.org/
+  specs:
+    rails-assets-momentjs (2.22.2)
+
+GEM
+  remote: https://rubygems.org/
   specs:
     actioncable (6.1.4.1)
       actionpack (= 6.1.4.1)
@@ -345,7 +349,6 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.4.1)
       sprockets-rails (>= 2.0.0)
-    rails-assets-momentjs (2.22.2)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)

--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -2,7 +2,7 @@
 @import 'nav';
 @import 'program';
 @import 'fonts';
-
+@import 'program';
 
 :root {
   --body_background_color: white;
@@ -43,9 +43,7 @@ body {
   max-width: 1070px;
   height: calc(100vh - 100px);
   margin: 0 auto;
-  border: 1px solid $black;
   overflow: scroll;
-  box-shadow: inset 0 0 0 1px $black; /** covers the weird border-radius 1px gap **/
   position: relative;
 }
 

--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -42,13 +42,13 @@ body {
   width: 95%;
   max-width: 1070px;
   height: calc(100vh - 100px);
+  background-color: var(--main_content_background);
   margin: 0 auto;
   overflow: scroll;
   position: relative;
 }
 
 #content {
-  background-color: var(--main_content_background);
   margin-left: 178px;
   padding: 50px 20px 20px 50px;
   position: relative;

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -13,6 +13,13 @@
     div {
       text-align: center;
     }
+
+    #header-logo-area {
+      img {
+        height: 100%;
+        width: 100%;
+      }
+    }
   }
 
   #main-nav {

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -2,7 +2,6 @@
   position: fixed;
   height: calc(100vh - 100px);
   width: 176px;
-  border-right: 1px solid $black;
   background: var(--nav_background_color);
   color: var(--nav_text_color);
 
@@ -23,7 +22,7 @@
       line-height: 50px;
       font-size: 14px;
       display: block;
-      border-bottom: 1px solid $divider;
+      border-top: 1px solid $black;
       background-color: var(--nav_background_color);
       color: var(--nav_text_color);
       &:hover {

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -54,7 +54,7 @@
   }
 
   .social-links {
-    display: flex; 
+    display: flex;
     flex-direction: row;
     align-items: center;
     border-bottom: 1px solid $divider;
@@ -110,7 +110,7 @@
 
       a {
         &#menu-toggle {
-          display: block; 
+          display: block;
           width: 64px;
           height: 64px;
           position: absolute;
@@ -128,7 +128,7 @@
         display: grid;
         grid-template-columns: 1fr 1fr 1fr;
         padding: 0;
-        
+
         a {
           height: 56px;
           display: block;
@@ -147,7 +147,7 @@
       border-left: 1px solid $black;
       width: 100%;
       display: block;
-      border-top: 1px solid $divider; 
+      border-top: 1px solid $divider;
       height: calc(100vh - 104px);
       transform: translate(0, calc(-100vh - 70px));
       transition: transform .35s ease-in-out;

--- a/app/assets/stylesheets/themes/default/program.scss
+++ b/app/assets/stylesheets/themes/default/program.scss
@@ -245,51 +245,22 @@
       padding: 15px 15px 0 15px;
       margin: 0 -15px -15px;
     }
+
     #tracks-nav {
-      background: $white;
-      border-bottom: 1px solid $divider;
-      border-radius: 0;
-      color: $darkest;
-      font-size: 16px;
-      left: 0;
-      opacity: 1;
-      padding: 15px 0;
-      text-align: center;
-      text-decoration: underline;
-      top: 78px;
-      width: 100%;
+      text-align: left;
+      right: 0;
+      top: 0;
+      background-color: var(--main_content_background);
       position: sticky;
-      strong {
-        display: none;
-      }
-
-      &:before {
-        content: 'Select a Track';
-      }
-
       ul {
-        margin: 15px 0 -15px 0;
         padding: 0;
         display: none;
-        height: 100vh;
-        background: $white image-url('themes/railsconf22/topo.png');
-        background-size: 1041px 1032px;
         li {
-          border-top: 1px solid $divider;
-          margin: 0;
+          margin-bottom: 3px;
           a {
-            background: $white;
-            border-left: 5px solid $brown;
-            border-right: 5px solid $brown;
+            border-left: 2px solid $brown;
             display: block;
-            font-size: 16px;
-            height: 48px;
-            line-height: 48px;
-            margin: 0;
-            padding: 0;
-          }
-          &.back-to-top {
-            border-bottom: 1px solid $divider;
+            padding: 2px 10px;
           }
         }
       }
@@ -302,6 +273,12 @@
         ul {
           display: block;
         }
+      }
+    }
+
+    #tracks-nav:hover {
+      ul {
+        display: block;
       }
     }
   }

--- a/app/assets/stylesheets/themes/default/program.scss
+++ b/app/assets/stylesheets/themes/default/program.scss
@@ -1,72 +1,3 @@
-
-#tracks-nav {
-  width: 190px;
-  right: 25px;
-  top: 175px;
-  position: fixed;
-  z-index: 3;
-  transition: all 0.25s ease-in-out;
-
-
-  strong {
-    color: $grey;
-    font-weight: 700;
-    display: block;
-    // @extend %mono;
-  }
-
-  ul {
-    margin: 5px 0 0 0;
-
-    li {
-      background: none;
-      margin: 0 0 4px 0;
-      padding: 0;
-
-      a {
-        font-size: 14px;
-        box-shadow: none;
-        text-shadow: none;
-        border-left: 3px solid $brown;
-        padding: 0 0 0 6px;
-        text-decoration: none;
-        color: $text;
-        &.track-rails-at-scale {
-          border-color: $rails_at_scale;
-        }
-        &.track-identity-permissions {
-          border-color: $identity_permissions;
-        }
-        &.track-creative-communications {
-          border-color: $creative_communications;
-        }
-        &.track-everything-activesupport {
-          border-color: $everything_activesupport;
-        }
-        &.track-soft-skills-are-hard {
-          border-color: $soft_skills_are_hard;
-        }
-        &.track-memorable-post-mortems {
-          border-color: $memorable_post_mortems;
-        }
-        &.track-exported-expertise {
-          border-color: $exported_expertise;
-        }
-        &:hover {
-          padding: 0 0 0 8px;
-        }
-      }
-      &.back-to-top a {
-        border: 0;
-        text-decoration: none;
-        padding: 0;
-      }
-    }
-  }
-}
-
-
-
 .program-nav {
   margin: 0;
   padding: 0;
@@ -172,20 +103,6 @@
   }
 }
 
-#sessions {
-  padding: 100px 250px 100px 100px;
-  width: auto;
-  h2 {
-    font-size: 36px;
-    font-weight: 700;
-    margin: 0 0 50px 0;
-  }
-}
-
-.session-anchor {
-  display: block;
-}
-
 .session-title {
   a {
     font-size: 18px;
@@ -197,69 +114,89 @@
   }
 }
 
-.session-author-details {
-  padding: 25px;
-  font-size: 14px;
-  background-color: $white;
-  background-image: image-url('themes/railsconf22/topo.png'),  image-url('themes/railsconf22/small-stripe.svg');
-  background-size: 1041px 1032px, 100% 3px;
-  background-position: 0 0, 0 top;
-  background-repeat: repeat, no-repeat;
-  margin: 0 -25px -25px;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
-  .session-author {
-    // @extend %mono;
-    font-weight: 600;
-  }
-}
-
-.session,
-.workshop {
+.workshop{
   margin: 0 0 25px 0;
-  position: relative;
-  box-shadow: 0 17px 24px rgba(52,44,34,.12);
-  border-radius: 5px;
-  background: $white;
-  background-size: 1041px 1032px;
+  border: 1px solid $black;
   padding: 25px;
-  font-size: 14px;
-  p {
-    line-height: 22px;
+} 
+
+
+#sessions {
+  padding: 50px 200px 50px 0px;
+  width: auto;
+  position: relative;
+
+  h2 {
+    font-size: 36px;
+    font-weight: 700;
+    margin: 0 0 50px 0;
   }
 }
 
-.track-name {
-  background: $general;
-  border-radius: 2px;
-  padding: 5px;
-  color: $white;
-  // @extend %mono;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  &.rails_at_scale {
-    background: $rails_at_scale;
+.session {
+  margin: 0 0 25px 0;
+  padding: 25px;
+
+  .session-anchor {
+    display: block;
   }
-  &.identity_permissions {
-    background: $identity_permissions;
+  
+  .session_abstract {
+    padding-bottom: 20px;
+    border-bottom: 1px solid black;
   }
-  &.creative_communications {
-    background: $creative_communications;
+
+  .track-name {
+    background: $general;
+    border-radius: 2px;
+    padding: 5px;
+    color: $white; 
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
   }
-  &.everything_activesupport {
-    background: $everything_activesupport;
+
+  .session-author-details {
+    padding-bottom: 20px;
   }
-  &.soft_skills_are_hard {
-    background: $soft_skills_are_hard;
-  }
-  &.memorable_post_mortems {
-    background: $memorable_post_mortems;
-  }
-  &.exported_expertise {
-    background: $exported_expertise;
+} 
+
+
+#tracks-nav {
+  width: 190px;
+  position: sticky;
+  float: right;
+  top: 50px;
+  margin-right: -200px;
+  transition: all 0.25s ease-in-out;
+  strong { display: block; }
+
+  ul {
+    margin: 10px 0 0 0;
+    padding: 0 0 0 0;
+
+    li {
+      background: none;
+      margin: 0 0 4px 0;
+      padding: 0;
+
+      a {
+        border-left: 3px solid $brown;
+        padding: 0 0 0 6px;
+        text-decoration: none;
+        &:hover {
+          padding: 0 0 0 8px;
+        }
+      }
+      &.back-to-top a {
+        border: 0;
+        text-decoration: none;
+        padding: 0;
+      }
+    }
   }
 }
+
 
 @media screen and (max-width: 900px) and (orientation: portrait),
   (max-width: 823px) and (orientation: landscape) {

--- a/app/assets/stylesheets/themes/default/program.scss
+++ b/app/assets/stylesheets/themes/default/program.scss
@@ -33,7 +33,7 @@
       font-weight: 600;
       display: block;
       color: $white;
-      text-decoration: none;    
+      text-decoration: none;
       &:hover {
         color: $gold;
       }
@@ -118,13 +118,14 @@
   margin: 0 0 25px 0;
   border: 1px solid $black;
   padding: 25px;
-} 
+}
 
 
 #sessions {
   padding: 50px 200px 50px 0px;
   width: auto;
   position: relative;
+  background-color: var(--main_content_background);
 
   h2 {
     font-size: 36px;
@@ -140,7 +141,7 @@
   .session-anchor {
     display: block;
   }
-  
+
   .session_abstract {
     padding-bottom: 20px;
     border-bottom: 1px solid black;
@@ -150,7 +151,7 @@
     background: $general;
     border-radius: 2px;
     padding: 5px;
-    color: $white; 
+    color: $white;
     font-size: 10px;
     font-weight: 600;
     text-transform: uppercase;
@@ -159,7 +160,7 @@
   .session-author-details {
     padding-bottom: 20px;
   }
-} 
+}
 
 
 #tracks-nav {

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,7 +1,8 @@
 class ProgramsController < ApplicationController
+  before_action :require_event
+
   def index
-    @program_session = current_website.event.program_sessions
+    @program_sessions = current_event.program_sessions.live
     render layout: "themes/#{current_website.theme}"
   end
 end
-

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,0 +1,8 @@
+class ScheduleController < ApplicationController
+  before_action :require_event
+
+  def index
+    @schedule = current_event.time_slots
+    render layout: "themes/#{current_website.theme}"
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -228,6 +228,10 @@ class Event < ApplicationRecord
     teammates.pluck(:mention_name)
   end
 
+  def number_of_workshops
+    program_sessions.filter {|session| session.session_format.name == 'Workshop' }.count
+  end
+
   private
 
   def update_closes_at_if_manually_closed

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -30,8 +30,7 @@
         %nav#main-nav
           - current_website.pages.published.each do |page|
             = link_to page.name, page_path(current_event, page)
-          %a{ href: program_page_path(current_event) }
-            Program
+          = link_to "Program", program_page_path(current_event)
           .social-links
             %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
             %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -31,6 +31,7 @@
           - current_website.pages.published.each do |page|
             = link_to page.name, page_path(current_event, page)
           = link_to "Program", program_page_path(current_event)
+          = link_to "Schedule", schedule_page_path(current_event)
           .social-links
             %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
             %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }

--- a/app/views/programs/_session.html.haml
+++ b/app/views/programs/_session.html.haml
@@ -1,0 +1,17 @@
+.session
+  %div
+    %a.session-anchor{ name: "session-#{session.id}" }
+    -if session.track
+      %span.track-name
+        = session.track_name
+    %h3.session-title
+      = link_to session.title, "#session-#{ session.id }"
+
+  .session_abstract
+    = session.abstract.html_safe
+  .session-author-details
+    -session.speakers.each do |speaker|
+      %h4.session-author
+        = speaker.speaker_name
+      .session-bio
+        = speaker.bio.html_safe

--- a/app/views/programs/index.html.haml
+++ b/app/views/programs/index.html.haml
@@ -1,1 +1,38 @@
-= @program_session
+%div
+  %h3
+    Program
+  %p
+    The largest official gathering of the year, RailsConf brings together top talent, companies, and project representatives from around the world. Learn and build with the best in sessions, workshops, keynotes and parties.
+  %ul.program_nav
+    %li.program-keynotes
+      Keynotes
+      %small
+        5
+    %li.program_sessions
+      %a{:href=>'#'}
+        Talks
+        %small
+          = @program_sessions.count
+    %li.program-workshops
+      %a{:href=>'#'}
+        Workshops  Talks
+        %small
+          = current_event.number_of_workshops
+
+#sessions
+  %nav#tracks-nav
+    %strong
+      Tracks
+    %ul
+      - current_event.tracks.each do |track|
+        %li
+          %a.track{ href: "#track-#{ track.name.dasherize }" }
+            = track.name
+      %li.back-to-top
+        %a{ href: "#sessions" }
+          &uparrow; Back To Top
+  %h2
+    Talks
+  - @program_sessions.each do |session|
+    %div
+      = render partial: 'session', locals: { session: session }

--- a/app/views/schedule/index.html.haml
+++ b/app/views/schedule/index.html.haml
@@ -1,0 +1,1 @@
+Home of Dynamic Schedule Grid.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,7 @@ Rails.application.routes.draw do
   get '/500', :to => 'errors#internal_error'
 
   get '/(:slug)', :to => 'pages#show', as: :landing
-  get '/(:slug)/program', :to => 'programs#index', :as => 'program_page'
+  get '/(:slug)/program', :to => 'programs#index', as: 'program_page'
+  get '/(:slug)/schedule', :to => 'schedule#index', as: 'schedule_page'
   get '/(:slug)/:page', :to => 'pages#show', as: :page
 end


### PR DESCRIPTION
# Description of Change
Display an events talks, and workshops on a '/program' page. 

## Notes
- Currently the Keynote speakers aren't stored in the CFP app. They are hardcoded on the conference website. We are going to have to deal with that
- Need to setup some scopes on the collection to separate  'Talks' from 'Workshops'
- Need to have a sort order on the Talks
- Annnd didn't wire up the talks nav 

Still working on the Schedule page. We should talk about it.  

## Preview Screenshots. 
<img width="586" alt="Screen Shot 2022-04-10 at 11 39 02 PM" src="https://user-images.githubusercontent.com/71521423/162671949-810335d5-b54f-4cac-9d1c-f9acc04df1f0.png">

<img width="859" alt="Screen Shot 2022-04-10 at 11 38 49 PM" src="https://user-images.githubusercontent.com/71521423/162671966-ef399d4a-2cb6-4622-929e-a2405e4843f1.png">
