### PR TITLE
Organizer Creates Event Website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ scratch.md
 yarn-debug.log*
 .yarn-integrity
 .vscode
+
+latest.dump*
+dump.rdb
+/storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -555,4 +555,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.15
+   2.3.11

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,9 +9,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   helper_method :current_event
+  helper_method :current_website
   helper_method :display_staff_event_subnav?
   helper_method :display_staff_selection_subnav?
   helper_method :display_staff_program_subnav?
+  helper_method :display_website_subnav?
   helper_method :program_mode?
   helper_method :schedule_mode?
   helper_method :program_tracks
@@ -49,6 +51,10 @@ class ApplicationController < ActionController::Base
 
   def current_event
     @current_event ||= set_current_event(session[:current_event_id]) if session[:current_event_id]
+  end
+
+  def current_website
+    current_event.website
   end
 
   def set_current_event(event_id)
@@ -140,6 +146,14 @@ class ApplicationController < ActionController::Base
 
   def enable_staff_schedule_subnav
     @display_schedule_subnav = true
+  end
+
+  def display_website_subnav?
+    @display_website_subnav
+  end
+
+  def enable_website_subnav
+    @display_website_subnav = true
   end
 
   def program_mode?

--- a/app/controllers/concerns/activate_navigation.rb
+++ b/app/controllers/concerns/activate_navigation.rb
@@ -56,6 +56,7 @@ module ActivateNavigation
             starts_with_path(:proposals),
             starts_with_path(:event_event_proposals, current_event)
         ],
+        'event-website-link' => website_subnav_item_map,
         'event-review-proposals-link' => starts_with_path(:event_staff_proposals, current_event),
         'event-selection-link' => selection_subnav_item_map,
         'event-program-link' => program_subnav_item_map,
@@ -75,6 +76,12 @@ module ActivateNavigation
         'event-staff-config-link' => exact_path(:event_staff_config, current_event),
         'event-staff-guidelines-link' => exact_path(:event_staff_guidelines, current_event),
         'event-staff-speaker-emails-link' => exact_path(:event_staff_speaker_email_notifications, current_event),
+    }
+  end
+
+  def website_subnav_item_map
+    @website_subnav_item_map ||= {
+      'event-website-configuration-link' => starts_with_path(:event_staff_website, current_event),
     }
   end
 

--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -1,0 +1,33 @@
+class Staff::WebsitesController < Staff::ApplicationController
+  before_action :set_website
+  before_action :authorize_website
+  before_action :enable_website_subnav
+
+  def new; end
+
+  def create
+    @website.save
+
+    flash[:success] = "Website was successfully created."
+    redirect_to event_staff_path(current_event)
+  end
+
+  def edit; end
+
+  def update
+    @website.save
+
+    flash[:success] = "Website was successfully updated."
+    redirect_to event_staff_path(current_event)
+  end
+
+  private
+
+  def set_website
+    @website = current_event.website || current_event.build_website
+  end
+
+  def authorize_website
+    authorize(@website)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -113,7 +113,19 @@ module ApplicationHelper
     current_user.staff_for?(current_event)
   end
 
+  def website_nav?
+    policy(Website).show?
+  end
+
   def admin_nav?
     current_user.admin?
+  end
+
+  def new_or_edit_website_path
+    if current_website
+      edit_event_staff_website_path(current_event)
+    else
+      new_event_staff_website_path(current_event)
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,7 @@ class Event < ApplicationRecord
   has_many :session_formats, dependent: :destroy
   has_many :taggings, through: :proposals
   has_many :ratings, through: :proposals
+  has_one :website
 
   has_many :public_session_formats, ->{ where(public: true) }, class_name: 'SessionFormat'
 

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -75,6 +75,10 @@ end
 #  info               :text
 #  created_at         :datetime
 #  updated_at         :datetime
+#  age_range          :string
+#  ethnicity          :string
+#  first_time_speaker :boolean
+#  pronouns           :string
 #
 # Indexes
 #

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,0 +1,21 @@
+class Website < ApplicationRecord
+  belongs_to :event
+end
+
+# == Schema Information
+#
+# Table name: websites
+#
+#  id         :bigint(8)        not null, primary key
+#  event_id   :bigint(8)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_websites_on_event_id  (event_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#

--- a/app/policies/website_policy.rb
+++ b/app/policies/website_policy.rb
@@ -1,0 +1,21 @@
+class WebsitePolicy < ApplicationPolicy
+  def show?
+    @user.organizer_for_event?(@current_event)
+  end
+
+  def new?
+    show?
+  end
+
+  def create?
+    show?
+  end
+
+  def edit?
+    show?
+  end
+
+  def update?
+    show?
+  end
+end

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -41,6 +41,13 @@
               = link_to event_staff_path(current_event) do
                 %span Dashboard
 
+          - if website_nav?
+            %li{class: nav_item_class("event-website-link")}
+              = link_to new_or_edit_website_path do
+                %span Website
+                %sup Beta
+
+
           - if admin_nav?
             = render partial: "layouts/nav/admin_nav"
 
@@ -63,3 +70,6 @@
 
 - elsif schedule_mode?
   = render partial: "layouts/nav/staff/schedule_subnav"
+
+- elsif display_website_subnav?
+  = render "layouts/nav/staff/website_subnav"

--- a/app/views/layouts/nav/staff/_website_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_website_subnav.html.haml
@@ -1,0 +1,6 @@
+.navbar.navbar-fixed-top.schedule-subnav
+  .container-fluid
+    %ul.nav.navbar-nav.navbar-right
+      %li{class: subnav_item_class('event-website-configuration-link')}
+        = link_to edit_event_staff_website_path(current_event) do
+          %span Configuration

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -1,0 +1,5 @@
+= simple_form_for website, url: :event_staff_website do |f|
+  .row
+    .col-sm-12
+      = submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
+      = link_to "Cancel", event_staff_path(current_event), {:class=>"cancel-form pull-right btn btn-danger"}

--- a/app/views/staff/websites/edit.html.haml
+++ b/app/views/staff/websites/edit.html.haml
@@ -1,0 +1,7 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      .btn-navbar.pull-right
+        %h1 Edit Website
+
+= render 'form', website: @website

--- a/app/views/staff/websites/new.html.haml
+++ b/app/views/staff/websites/new.html.haml
@@ -1,0 +1,7 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      .btn-navbar.pull-right
+        %h1 New Website
+
+= render 'form', website: @website

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
 
       resources :session_formats, except: :show
       resources :tracks, except: [:show]
+      resource :website, only: [:new, :create, :edit, :update]
     end
   end
 

--- a/db/migrate/20220412104802_create_websites.rb
+++ b/db/migrate/20220412104802_create_websites.rb
@@ -1,0 +1,9 @@
+class CreateWebsites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :websites do |t|
+      t.belongs_to :event, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_24_020710) do
+ActiveRecord::Schema.define(version: 2022_04_12_104802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -265,5 +265,13 @@ ActiveRecord::Schema.define(version: 2021_05_24_020710) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  create_table "websites", force: :cascade do |t|
+    t.bigint "event_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_websites_on_event_id"
+  end
+
   add_foreign_key "session_formats", "events"
+  add_foreign_key "websites", "events"
 end

--- a/spec/factories/websites.rb
+++ b/spec/factories/websites.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :website do
+    event
+  end
+end

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature "Website Configuration" do
+  let(:event) { create(:event) }
+  let(:organizer) { create(:organizer, event: event) }
+
+  scenario "Organizer configures a new website for event" do
+    login_as(organizer)
+
+    visit event_path(event)
+    within('.navbar') { click_on("Website") }
+    click_on("Save")
+
+    expect(page).to have_content("Website was successfully created")
+    expect(event.website).to be_present
+  end
+
+  scenario "Organizer configures an existing website for event" do
+    website = create(:website, event: event)
+    login_as(organizer)
+
+    visit event_path(website.event)
+    within('.navbar') { click_on("Website") }
+
+    expect(page).to have_content("Edit Website")
+
+    click_on("Save")
+
+    expect(page).to have_content("Website was successfully updated")
+  end
+end

--- a/spec/policies/website_policy_spec.rb
+++ b/spec/policies/website_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe WebsitePolicy do
+  let(:event) { create(:event) }
+  let(:program_team) { create(:program_team, event: event) }
+  let(:organizer) { create(:organizer, event: event) }
+  let(:admin) { create(:admin) }
+
+  subject { described_class }
+
+  def pundit_user(user)
+    CurrentEventContext.new(user, event)
+  end
+
+  permissions :show?, :new?, :create?, :edit?, :update? do
+    it 'allows organizers for event' do
+      expect(subject).to permit(pundit_user(organizer))
+    end
+
+    it 'does not allow program team users' do
+      expect(subject).not_to permit(pundit_user(program_team))
+    end
+
+    it 'does not allow admin users' do
+      expect(subject).not_to permit(pundit_user(admin))
+    end
+  end
+end
+
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,4 +71,4 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = ENV['CHROME'] ? :chrome : :headless_chrome

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,13 +18,13 @@ RSpec.configure do |config|
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
   config.raise_errors_for_deprecations!
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 =begin
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
## Summary

This PR covers a very minimal feature of an "Organizer Creating a Event Website". It merely builds out the initial model and some basic routes, controller, views and authorization that will be built upon in upcoming PRs.

The Website model, while currently just an association to the Event model, will soon be used for data and logic needed for configuration of the website. It also will help keep the logic and associations related to the website generation and presentation isolated from the Event god object. 

The PR tries to mostly follow existing patterns (e.g. navigation/sub-navigation) without getting lost in possible refactorings. However, the [decent_exposure](https://github.com/hashrocket/decent_exposure) gem was added for developer happiness. 

## Commit Notes
- adds Website model and belongs_to association to Event
- adds website resource routes within event staff scopes
- adds WebsitePolicy for organizer authorization
- adds initial Website navigation with Configuration subnav
- adds feature spec for website creation
- adds decent_exposure for developer controller/view happiness
- updates gitignore to exclude local dump and storage files