### PR TITLE
Updates to the setup script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '2.7.4'
+
+# https://andycroll.com/ruby/read-ruby-version-in-your-gemfile/
+ruby File.read(".ruby-version").strip
 
 gem 'puma'
 gem 'rails', '~> 6.1.0'

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ The CFP App does not provide a public facing website for your conference, though
 
 ### Prerequisite Requirements
 
-* Ruby 2.7.2
-* Bundler (was installed with 2.1.4)
-* PostgreSQL
+* Ruby 2.7.4 (set in `.ruby-version`)
+* Bundler (was installed with 2.2.15)
+* PostgreSQL 14.1
+* Google Chrome browser must be installed to run tests
 
 Make sure you have Ruby and Postgres installed in your environment.  Double check in the [Gemfile](../blob/master/Gemfile) for the exact supported version.  This is a Rails 6 app and uses bundler to install all required gems.  We are also making the assumption that you're familiar with how Rails apps are setup and deployed.  If this is not the case then you'll want to refer to documentation that will bridge any gaps in the instructions below.
 
@@ -30,21 +31,20 @@ Run [bin/setup](bin/setup) script to install gem dependencies and setup database
 bin/setup
 ```
 
-This will create `.env` and a development database with seed data. Seeds will make an admin user with an email of `an@admin.com` and password of `userpass` to get you started.
+This script will:
 
-You will also need to install the JavaScript packages. To do that run:
+- Install Ruby dependencies
+- Install Javascript dependencies
+- Setup the database
+- Clear old logs and tempfiles
+- Create `.env` and a development database with seed data. Seeds will make an admin user with an email of `an@admin.com` and password of `userpass` to get you started
+- Run the test suite
 
-```bash
-yarn install --check-files
-```
-
-Start the server:
+To start the server on port 3000:
 
 ```bash
 bin/rails server
 ```
-
-Runs on port 3000.
 
 If you have the heroku toolbelt installed you can also use:
 
@@ -52,7 +52,7 @@ If you have the heroku toolbelt installed you can also use:
 heroku local
 ```
 
-This will boot up using Foreman and allow the .env file to be read / set for use locally. Runs on port 5000.
+This will boot up using Foreman and allow the `.env` file to be read / set for use locally. Runs on port 5000.
 
 ### Environment variables
 

--- a/bin/setup
+++ b/bin/setup
@@ -17,13 +17,8 @@ FileUtils.chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies
-  # system('bin/yarn')
-
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  puts "\n== Installing JavaScript dependencies =="
+  system! 'yarn install --check-files'
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'
@@ -33,4 +28,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Restarting application server =="
   system! 'bin/rails restart'
+
+  puts "\n== Run the tests =="
+  system! 'bin/rspec'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = "tmp/examples.txt"
 =begin
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with


### PR DESCRIPTION
Reason for Change
=================
* I was trying to get the app setup locally and ran into some issues.
* I usually look to `bin/setup` for all of the required info, some of the steps were missing.

Changes
=======
* Removed some info in `README.md` and moved it into the `bin/setup` script
* Added the yarn setup task to the setup script
* Run the specs at the end of the setup script to ensure all is well
* Added a note about Google Chrome needing to be installed

Minor
=====
* Specify the Ruby version in one place, `.ruby-version` and have the `Gemfile` look for it there
* Store rspec results in `/tmp` for reuse with things like `rspec --only-failures`