### PR TITLE
Organizer Adds Website Page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'nokogiri'
 gem 'pundit'
 gem 'redcarpet', '~> 3.5'
 gem 'simple_form'
+gem 'tinymce-rails'
 
 gem 'react-rails'
 gem 'webpacker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,8 @@ GEM
     thor (1.1.0)
     tilt (2.0.10)
     timecop (0.9.4)
+    tinymce-rails (5.10.3)
+      railties (>= 3.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
@@ -545,6 +547,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   timecop
+  tinymce-rails
   uglifier (>= 1.3.0)
   underscore-rails
   web-console

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,4 +26,5 @@
 //= require momentjs
 //= require selectize
 //= require palette.js
+//= require tinymce
 //= require_tree .

--- a/app/assets/stylesheets/modules/_navbar.scss
+++ b/app/assets/stylesheets/modules/_navbar.scss
@@ -174,7 +174,9 @@
   }
 }
 
-.navbar-fixed-top.program-subnav, .navbar-fixed-top.schedule-subnav {
+.navbar-fixed-top.program-subnav,
+.navbar-fixed-top.schedule-subnav,
+.navbar-fixed-top.website-subnav {
   border-radius: 0;
   background-color: $dark-blue;
   border-color: $dark-blue;

--- a/app/controllers/concerns/activate_navigation.rb
+++ b/app/controllers/concerns/activate_navigation.rb
@@ -82,6 +82,7 @@ module ActivateNavigation
   def website_subnav_item_map
     @website_subnav_item_map ||= {
       'event-website-configuration-link' => starts_with_path(:event_staff_website, current_event),
+      'event-pages-link' => exact_path(:event_staff_pages, current_event)
     }
   end
 

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -11,19 +11,24 @@ class Staff::PagesController < Staff::ApplicationController
   def new; end
 
   def create
-    @page.update(page_params)
-    flash[:success] = "#{@page.name} Page was successfully created."
-    redirect_to event_staff_pages_path(current_event, @page)
+    if @page.update(page_params)
+      flash[:success] = "#{@page.name} Page was successfully created."
+      redirect_to event_staff_pages_path(current_event, @page)
+    else
+      render :new
+    end
   end
 
   def edit; end
 
   def update
-    @page.update(page_params)
-    flash[:success] = "#{@page.name} Page was successfully updated."
-    redirect_to event_staff_pages_path(current_event, @page)
+    if @page.update(page_params)
+      flash[:success] = "#{@page.name} Page was successfully updated."
+      redirect_to event_staff_pages_path(current_event, @page)
+    else
+      render :edit
+    end
   end
-
 
   private
 
@@ -33,7 +38,6 @@ class Staff::PagesController < Staff::ApplicationController
             else
               current_website.pages.build
             end
-
   end
 
   def authorize_page

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -1,0 +1,46 @@
+class Staff::PagesController < Staff::ApplicationController
+  before_action :enable_website_subnav
+  before_action :set_page, except: :index
+  before_action :authorize_page, except: :index
+
+  def index
+    @pages = current_website.pages
+    authorize(@pages)
+  end
+
+  def new; end
+
+  def create
+    @page.update(page_params)
+    flash[:success] = "#{@page.name} Page was successfully created."
+    redirect_to event_staff_pages_path(current_event, @page)
+  end
+
+  def edit; end
+
+  def update
+    @page.update(page_params)
+    flash[:success] = "#{@page.name} Page was successfully updated."
+    redirect_to event_staff_pages_path(current_event, @page)
+  end
+
+
+  private
+
+  def set_page
+    @page = if params[:id]
+              current_website.pages.find_by(slug: params[:id])
+            else
+              current_website.pages.build
+            end
+
+  end
+
+  def authorize_page
+    authorize(@page)
+  end
+
+  def page_params
+    params.require(:page).permit(:name, :slug, :unpublished_body)
+  end
+end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = ['input']
+
+  initialize () {
+    this.defaults = {
+      height: 500,
+      menubar: false,
+      plugins: [
+        'advlist autolink lists link image charmap print preview anchor',
+        'searchreplace visualblocks code fullscreen',
+        'insertdatetime media table paste code help wordcount'
+      ],
+        toolbar: 'undo redo | formatselect | ' +
+        ' bold italic backcolor | alignleft aligncenter ' +
+        ' alignright alignjustify | bullist numlist outdent indent | ' +
+        ' removeformat | code | help'
+    }
+  }
+
+  connect () {
+    let config = Object.assign({ target: this.inputTarget }, this.defaults)
+    tinyMCE.init(config)
+  }
+
+  disconnect () {
+    tinymce.remove()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories. 
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,3 +20,5 @@ console.log('Hello World from Webpacker')
 var componentRequireContext = require.context("components", true);
 var ReactRailsUJS = require("react_ujs");
 ReactRailsUJS.useContext(componentRequireContext);
+
+import "controllers"

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,8 @@
 class Page < ApplicationRecord
   belongs_to :website
 
+  validates :name, :slug, presence: true
+
   def to_param
     slug
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,29 @@
+class Page < ApplicationRecord
+  belongs_to :website
+
+  def to_param
+    slug
+  end
+end
+
+# == Schema Information
+#
+# Table name: pages
+#
+#  id               :bigint(8)        not null, primary key
+#  name             :string
+#  slug             :string
+#  website_id       :bigint(8)
+#  published_body   :text
+#  unpublished_body :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_pages_on_website_id  (website_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (website_id => websites.id)
+#

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,5 +1,6 @@
 class Website < ApplicationRecord
   belongs_to :event
+  has_many :pages
 end
 
 # == Schema Information

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,0 +1,21 @@
+class PagePolicy < ApplicationPolicy
+  def index?
+    @user.organizer_for_event?(@current_event)
+  end
+
+  def new?
+    index?
+  end
+
+  def create?
+    new?
+  end
+
+  def edit?
+    new?
+  end
+
+  def update?
+    new?
+  end
+end

--- a/app/views/layouts/nav/staff/_website_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_website_subnav.html.haml
@@ -1,5 +1,9 @@
-.navbar.navbar-fixed-top.schedule-subnav
+.navbar.navbar-fixed-top.website-subnav
   .container-fluid
+    %ul.nav.navbar-nav.navbar-right
+      %li{class: subnav_item_class('event-pages-link')}
+        = link_to event_staff_pages_path(current_event) do
+          %span Pages
     %ul.nav.navbar-nav.navbar-right
       %li{class: subnav_item_class('event-website-configuration-link')}
         = link_to edit_event_staff_website_path(current_event) do

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -1,0 +1,13 @@
+= simple_form_for [current_event, :staff, page] do |f|
+  .row
+    %fieldset.col-md-6
+      = f.input :name
+      = f.input :slug
+      = f.input :unpublished_body,
+        as: :text,
+        wrapper_html: { data: { controller: :editor } },
+        input_html: { data: { "editor-target": 'input' } }
+  .row
+    .col-sm-12
+      = submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
+      = link_to "Cancel", event_staff_pages_path(current_event), {:class=>"cancel-form pull-right btn btn-danger"}

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -1,0 +1,3 @@
+%tr
+  %td= link_to(page.name, edit_event_staff_page_path(current_event, page))
+  %td= link_to(page.slug, edit_event_staff_page_path(current_event, page))

--- a/app/views/staff/pages/edit.html.haml
+++ b/app/views/staff/pages/edit.html.haml
@@ -1,0 +1,6 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      %h1 Edit #{@page.name} Page
+
+= render 'form', page: @page

--- a/app/views/staff/pages/index.html.haml
+++ b/app/views/staff/pages/index.html.haml
@@ -1,0 +1,17 @@
+.row
+  .col-md-8
+    %h3
+      Website Page
+      %span.badge= @pages.count
+  .col-md-4.text-right
+    = link_to "+ New Page", new_event_staff_page_path(current_event), class: "btn btn-success btn-sm"
+.row
+  .col-md-12
+    %table.datatable.table.table-striped
+      %thead
+        %tr
+          %th Name
+          %th Slug
+      %tbody
+        = render @pages
+%hr

--- a/app/views/staff/pages/new.html.haml
+++ b/app/views/staff/pages/new.html.haml
@@ -1,0 +1,6 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      %h1 New Website Page
+
+= render 'form', page: @page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
       resources :session_formats, except: :show
       resources :tracks, except: [:show]
       resource :website, only: [:new, :create, :edit, :update]
+      resources :pages, only: [:index, :new, :create, :edit, :update]
     end
   end
 

--- a/db/migrate/20220412153740_create_pages.rb
+++ b/db/migrate/20220412153740_create_pages.rb
@@ -1,0 +1,13 @@
+class CreatePages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :pages do |t|
+      t.string :name
+      t.string :slug
+      t.belongs_to :website, foreign_key: true
+      t.text :published_body
+      t.text :unpublished_body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220412153740_create_pages.rb
+++ b/db/migrate/20220412153740_create_pages.rb
@@ -1,8 +1,8 @@
 class CreatePages < ActiveRecord::Migration[6.1]
   def change
     create_table :pages do |t|
-      t.string :name
-      t.string :slug
+      t.string :name, null: false
+      t.string :slug, null: false
       t.belongs_to :website, foreign_key: true
       t.text :published_body
       t.text :unpublished_body

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_104802) do
+ActiveRecord::Schema.define(version: 2022_04_12_153740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,17 @@ ActiveRecord::Schema.define(version: 2022_04_12_104802) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
+  create_table "pages", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+    t.bigint "website_id"
+    t.text "published_body"
+    t.text "unpublished_body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["website_id"], name: "index_pages_on_website_id"
   end
 
   create_table "program_sessions", force: :cascade do |t|
@@ -272,6 +283,7 @@ ActiveRecord::Schema.define(version: 2022_04_12_104802) do
     t.index ["event_id"], name: "index_websites_on_event_id"
   end
 
+  add_foreign_key "pages", "websites"
   add_foreign_key "session_formats", "events"
   add_foreign_key "websites", "events"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,8 +75,8 @@ ActiveRecord::Schema.define(version: 2022_04_12_153740) do
   end
 
   create_table "pages", force: :cascade do |t|
-    t.string "name"
-    t.string "slug"
+    t.string "name", null: false
+    t.string "slug", null: false
     t.bigint "website_id"
     t.text "published_body"
     t.text "unpublished_body"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react_ujs": "^2.5.0",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "stimulus": "^3.0.1"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.3.1"

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature "Website Page Management" do
+  let(:event) { create(:event) }
+  let(:organizer) { create(:organizer, event: event) }
+
+  scenario "Organizer creates and edits a website page", :js do
+    create(:website, event: event)
+    login_as(organizer)
+
+    visit event_path(event)
+    within('.navbar') { click_on("Website") }
+    within('.website-subnav') { click_on("Pages") }
+    click_on "New Page"
+
+    fill_in('Name', with: 'Home')
+    fill_in('Slug', with: 'home')
+    fill_in_tinymce(:page, :unpublished_body, 'Come Code With Us')
+    click_on('Save')
+
+    expect(page).to have_content('Home Page was successfully created')
+
+    click_on('Home')
+    expect(page).to have_content('Edit Home Page')
+    fill_in_tinymce(:page, :unpublished_body, :enter)
+    fill_in_tinymce(:page, :unpublished_body, 'In Asheville, NC')
+    click_on('Save')
+
+    expect(page).to have_content('Home Page was successfully updated')
+  end
+end

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -13,6 +13,10 @@ feature "Website Page Management" do
     within('.website-subnav') { click_on("Pages") }
     click_on "New Page"
 
+    click_on('Save')
+    within('.page_name') { expect(page).to have_content("can't be blank") }
+    within('.page_slug') { expect(page).to have_content("can't be blank") }
+
     fill_in('Name', with: 'Home')
     fill_in('Slug', with: 'home')
     fill_in_tinymce(:page, :unpublished_body, 'Come Code With Us')

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe PagePolicy do
+  let(:event) { create(:event) }
+  let(:program_team) { create(:program_team, event: event) }
+  let(:organizer) { create(:organizer, event: event) }
+  let(:admin) { create(:admin) }
+
+  subject { described_class }
+
+  def pundit_user(user)
+    CurrentEventContext.new(user, event)
+  end
+
+  permissions :new?, :create?, :edit?, :update? do
+    it 'allows organizers for event' do
+      expect(subject).to permit(pundit_user(organizer))
+    end
+
+    it 'does not allow program team users' do
+      expect(subject).not_to permit(pundit_user(program_team))
+    end
+
+    it 'does not allow admin users' do
+      expect(subject).not_to permit(pundit_user(admin))
+    end
+  end
+end
+
+

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,5 +1,7 @@
 require 'support/helpers/session_helpers'
+require 'support/helpers/form_helpers'
 
 RSpec.configure do |config|
   config.include Features::SessionHelpers, type: :feature
+  config.include Features::FormHelpers, type: :feature
 end

--- a/spec/support/helpers/form_helpers.rb
+++ b/spec/support/helpers/form_helpers.rb
@@ -1,0 +1,10 @@
+module Features
+  module FormHelpers
+    def fill_in_tinymce(resource, field, content)
+      within_frame("#{resource}_#{field}_ifr") do
+        editor = page.find_by_id('tinymce')
+        editor.native.send_keys(content)
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,6 +942,16 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@hotwired/stimulus-webpack-helpers@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
+  integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==
+
+"@hotwired/stimulus@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
+  integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
+
 "@npmcli/fs@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.0.0.tgz#589612cfad3a6ea0feafcb901d29c63fd52db09f"
@@ -6286,6 +6296,14 @@ static-extend@^0.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+stimulus@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-3.0.1.tgz#370e3054eb3b8068904af1888949821255d375d3"
+  integrity sha512-73uZG5E5bwH7W2BldieTXg4yJuEmOfIHgtO/aqwU0JkWNjwY75ZaoOAD2EEPvi5AK43N9adEeOQOmlgWf59HOg==
+  dependencies:
+    "@hotwired/stimulus" "^3.0.1"
+    "@hotwired/stimulus-webpack-helpers" "^1.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Organizer Adds Website Page

Reason for Change
=================

This PR sets up the page object for organizers to create and update. Fields for both `unpublished_body` and `published_body` are included though only currently the former is being used. The ability to view the page content and the ability to preview and publish will come in future PRs. 

WYSIWYG editing for the page content is currently being done with TinyMCE which can be a bit tricky to figure out the best way to install and configure. Trix was considered as an alternative but during the spike some challenges were bumped into the opinionated way that it sanitized and marked up the html. Additionally, TinyMCE has a plugin for editing the html code which may prove valuable to developers skilled with html and css. Unfortunately the html is not syntax highlighted in the code editor but in the spike a way was found to use [CodeMirror](https://codemirror.net/) for that if desired. 

StimulusJS is added to provide a more organized way to structure and include javascript driven functionality. This library has become a standard way to work with the front end for Rails developers and seems like a good fit for our purposes going forward. 

Changes
=======
- adds basic CRUD for event organizers to manage website pages
- adds PagePolicy for authorization
- adds tinymce editor using tinymce rails gem
- installs stimulusjs using webpacker
- adds editor_controller for initializing the tinymce editor

[Mirror Card](https://miro.com/app/board/uXjVOA-0gUs=/?moveToWidget=3458764523048559109&cot=14)
[Heroku PR Review App](https://cfp-app-flagrant-websit-agjw4y.herokuapp.com/events/decemberconf)