### PR TITLE
Organizer Previews Website Page

### DIFF
--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -8,6 +8,11 @@ class Staff::PagesController < Staff::ApplicationController
     authorize(@pages)
   end
 
+  def show
+    @body = @page.unpublished_body
+    render template: 'pages/show', layout: "themes/#{current_website.theme}"
+  end
+
   def new; end
 
   def create
@@ -29,6 +34,8 @@ class Staff::PagesController < Staff::ApplicationController
       render :edit
     end
   end
+
+  def preview; end
 
   def publish
     @page.update(published_body: @page.unpublished_body)

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -19,6 +19,14 @@ class PagePolicy < ApplicationPolicy
     new?
   end
 
+  def show?
+    new?
+  end
+
+  def preview?
+    new?
+  end
+
   def publish?
     new?
   end

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -1,7 +1,12 @@
 %tr
   %td= link_to(page.name, edit_event_staff_page_path(current_event, page))
   %td= link_to(page.slug, edit_event_staff_page_path(current_event, page))
-  %td= button_to("Publish",
-    publish_event_staff_page_path(current_event, page),
-    data: { confirm: "Are you sure you want to publish?" },
-    class: 'btn btn-primary btn-sm')
+  %td
+    = link_to("Preview",
+      preview_event_staff_page_path(current_event, page),
+      class: 'btn btn-primary')
+    = link_to("Publish",
+      publish_event_staff_page_path(current_event, page),
+      method: :patch,
+      data: { confirm: "Are you sure you want to publish?" },
+      class: 'btn btn-primary')

--- a/app/views/staff/pages/preview.html.haml
+++ b/app/views/staff/pages/preview.html.haml
@@ -1,0 +1,18 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      %h1 Preview #{@page.name} Page
+
+%iframe{
+  src: "#{event_staff_page_path(current_event, @page)}",
+  width: "100%",
+  style: "height:90vh;",
+  id: "page-preview"}
+
+.row
+  .col-sm-12
+    = link_to("Publish",
+      publish_event_staff_page_path(current_event, @page),
+      method: :patch,
+      data: { confirm: "Are you sure you want to publish?" },
+      class: 'btn btn-primary')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,9 +109,10 @@ Rails.application.routes.draw do
       resources :session_formats, except: :show
       resources :tracks, except: [:show]
       resource :website, only: [:new, :create, :edit, :update]
-      resources :pages, only: [:index, :new, :create, :edit, :update] do
+      resources :pages, except: :destroy do
         member do
-          post :publish
+          get :preview
+          patch :publish
         end
       end
     end

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -33,6 +33,18 @@ feature "Website Page Management" do
     expect(page).to have_content('Home Page was successfully updated')
   end
 
+  scenario "Organizer previews a website page", :js do
+    create(:page, unpublished_body: 'Home Content', published_body: nil)
+    login_as(organizer)
+
+    visit event_staff_pages_path(event)
+    click_on('Preview')
+
+    within_frame('page-preview') do
+      expect(page).to have_content('Home Content')
+    end
+  end
+
   scenario "Organizer publishes a website page", :js do
     home_page = create(:page, unpublished_body: 'Home Content', published_body: nil)
     login_as(organizer)

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PagePolicy do
     CurrentEventContext.new(user, event)
   end
 
-  permissions :index?, :new?, :create?, :edit?, :update?, :publish? do
+  permissions :index?, :new?, :create?, :edit?, :update?, :show?, :preview?, :publish? do
     it 'allows organizers for event' do
       expect(subject).to permit(pundit_user(organizer))
     end


### PR DESCRIPTION
Organizer Previews Website Page

Reason for Change
=================

This PR builds on the publishing of a website page by providing a backend preview view of the unpublished content before it gets published. 

Changes
=======
- adds preview page for unpublished_body using iframe with frontend
  layout
- fixes button styles for publishing button as well

[Miro Card](https://miro.com/app/board/uXjVOA-0gUs=/?moveToWidget=3458764523048559109&cot=14)
[PR Review App](https://cfp-app-flagrant-websit-zdg1dq.herokuapp.com/)