### PR TITLE
CRUD for Event Sponsor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,8 @@ GIT
     mimemagic (0.3.5)
 
 GEM
-  remote: https://rails-assets.org/
-  specs:
-    rails-assets-momentjs (2.22.2)
-
-GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actioncable (6.1.4.1)
       actionpack (= 6.1.4.1)
@@ -349,6 +345,7 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.4.1)
       sprockets-rails (>= 2.0.0)
+    rails-assets-momentjs (2.22.2)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -555,7 +552,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.4p191
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.3.11

--- a/app/controllers/staff/sponsors_controller.rb
+++ b/app/controllers/staff/sponsors_controller.rb
@@ -1,4 +1,5 @@
 class Staff::SponsorsController < Staff::ApplicationController
+  before_action :enable_website_subnav
 
   def index
     @sponsors = current_event.sponsors

--- a/app/controllers/staff/sponsors_controller.rb
+++ b/app/controllers/staff/sponsors_controller.rb
@@ -1,0 +1,23 @@
+class Staff::SponsorsController < Staff::ApplicationController
+
+  def index
+    @sponsors = current_event.sponsors
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  private
+  def sponsors_params
+    params.require(:sponsor).permit(:name, :tier, :published, :url, :other_title)
+  end
+end

--- a/app/controllers/staff/sponsors_controller.rb
+++ b/app/controllers/staff/sponsors_controller.rb
@@ -27,6 +27,13 @@ class Staff::SponsorsController < Staff::ApplicationController
     redirect_to event_staff_sponsors_path
   end
 
+  def destroy
+    @sponsor = current_event.sponsors.find(params[:id])
+    @sponsor.destroy
+    redirect_to event_staff_sponsors_path
+    flash[:info] = "Sponsor was successfully removed."
+  end
+
   private
   def sponsors_params
     params.require(:sponsor).permit(:name, :tier, :published, :url, :other_title)

--- a/app/controllers/staff/sponsors_controller.rb
+++ b/app/controllers/staff/sponsors_controller.rb
@@ -5,15 +5,25 @@ class Staff::SponsorsController < Staff::ApplicationController
   end
 
   def new
+    @sponsor = current_event.sponsors.build
   end
 
   def create
+    @sponsor = current_event.sponsors.build(sponsors_params)
+
+    flash[:success] = "Sponsor was successfully created."
+    redirect_to event_staff_sponsors_path if @sponsor.save
   end
 
   def edit
+    @sponsor = current_event.sponsors.find_by(id: params[:id])
   end
 
   def update
+    @sponsor = current_event.sponsors.find_by(id: params[:id])
+    @sponsor.update(sponsors_params)
+    flash[:success] = "#{@sponsor.name} was successfully updated."
+    redirect_to event_staff_sponsors_path
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,6 +117,10 @@ module ApplicationHelper
     policy(Website).show?
   end
 
+  def sponsor_nav?
+    policy(Sponsor).show?
+  end
+
   def admin_nav?
     current_user.admin?
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,7 @@ class Event < ApplicationRecord
   has_many :session_formats, dependent: :destroy
   has_many :taggings, through: :proposals
   has_many :ratings, through: :proposals
+  has_many :sponsors
   has_one :website
 
   has_many :public_session_formats, ->{ where(public: true) }, class_name: 'SessionFormat'

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,0 +1,2 @@
+class Sponsor < ApplicationRecord
+end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,3 +1,5 @@
 class Sponsor < ApplicationRecord
   belongs_to :event
+
+  TIERS = ['platinum', 'gold', 'silver', 'bronze', 'other', 'supporter']
 end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,2 +1,3 @@
 class Sponsor < ApplicationRecord
+  belongs_to :event
 end

--- a/app/policies/sponsor_policy.rb
+++ b/app/policies/sponsor_policy.rb
@@ -1,0 +1,21 @@
+class SponsorPolicy < ApplicationPolicy
+  def show?
+    @user.organizer_for_event?(@current_event)
+  end
+
+  def new?
+    show?
+  end
+
+  def create?
+    show?
+  end
+
+  def edit?
+    show?
+  end
+
+  def update?
+    show?
+  end
+end

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -47,6 +47,11 @@
                 %span Website
                 %sup Beta
 
+          - if sponsor_nav?
+            %li{class: nav_item_class("event-sponsors-link")}
+              = link_to event_staff_sponsors_path do
+                %span Sponsors
+                %sup Beta
 
           - if admin_nav?
             = render partial: "layouts/nav/admin_nav"

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -47,12 +47,6 @@
                 %span Website
                 %sup Beta
 
-          - if sponsor_nav?
-            %li{class: nav_item_class("event-sponsors-link")}
-              = link_to event_staff_sponsors_path do
-                %span Sponsors
-                %sup Beta
-
           - if admin_nav?
             = render partial: "layouts/nav/admin_nav"
 

--- a/app/views/layouts/nav/staff/_website_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_website_subnav.html.haml
@@ -1,10 +1,13 @@
 .navbar.navbar-fixed-top.website-subnav
   .container-fluid
     %ul.nav.navbar-nav.navbar-right
-      %li{class: subnav_item_class('event-pages-link')}
-        = link_to event_staff_pages_path(current_event) do
-          %span Pages
-    %ul.nav.navbar-nav.navbar-right
       %li{class: subnav_item_class('event-website-configuration-link')}
         = link_to edit_event_staff_website_path(current_event) do
           %span Configuration
+      %li{class: subnav_item_class('event-pages-link')}
+        = link_to event_staff_pages_path(current_event) do
+          %span Pages
+      %li{class: subnav_item_class('event-sponsor-link')}
+        = link_to event_staff_sponsors_path do
+          %span Sponsors
+          %sup Beta

--- a/app/views/staff/sponsors/_form.html.haml
+++ b/app/views/staff/sponsors/_form.html.haml
@@ -1,0 +1,14 @@
+= simple_form_for @sponsor, url: [ event, :staff, @sponsor ] do |f|
+  .row
+    %fieldset.col-md-6
+      = f.input :name, maxlength: 60, input_html: { class: 'watched js-maxlength-alert', rows: 1 }
+      = f.input :other_title
+      = f.input :tier, collection: Sponsor::TIERS
+      = f.input :url
+      = f.input :published, as: :boolean, wrapper: :vertical_radio_and_checkboxes
+
+    .col-sm-12
+      = link_to "Cancel", event_staff_sponsors_path, class: "pull-right btn btn-danger"
+      =submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
+
+

--- a/app/views/staff/sponsors/_form.html.haml
+++ b/app/views/staff/sponsors/_form.html.haml
@@ -8,7 +8,5 @@
       = f.input :published, as: :boolean, wrapper: :vertical_radio_and_checkboxes
 
     .col-sm-12
-      = link_to "Cancel", event_staff_sponsors_path, class: "pull-right btn btn-danger"
-      =submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
-
-
+      = submit_tag("Save", class: "btn btn-success", type: "submit")
+      = link_to "Cancel", event_staff_sponsors_path, class: "btn btn-default"

--- a/app/views/staff/sponsors/_sponsor.html.haml
+++ b/app/views/staff/sponsors/_sponsor.html.haml
@@ -1,0 +1,10 @@
+
+%tr
+  %td= sponsor.name
+  %td= sponsor.tier
+  %td= sponsor.published
+  %td
+    %a{ href: sponsor.url, target: "_blank" }
+      = sponsor.url
+  %td= sponsor.other_title
+  %td= link_to "Edit Sponsor", edit_event_staff_sponsor_path(current_event, sponsor)

--- a/app/views/staff/sponsors/edit.html.haml
+++ b/app/views/staff/sponsors/edit.html.haml
@@ -1,0 +1,6 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      %h1 Edit #{@sponsor.name}
+
+= render 'form', sponsor: @sponsor

--- a/app/views/staff/sponsors/edit.html.haml
+++ b/app/views/staff/sponsors/edit.html.haml
@@ -1,6 +1,12 @@
 .row
   .col-md-12
     .page-header.clearfix
+      .btn-navbar.pull-right
+        = link_to event_staff_sponsor_path(current_event, @sponsor),
+          method: :delete, data: { confirm: 'Are you sure? Confirming this action will remove the sponsor from the event website. Are you sure you want to do this? ' + 'It can not be undone.' },
+          class: 'btn btn-danger navbar-btn', id: 'delete' do
+          %span.glyphicon.glyphicon-exclamation-sign
+          Delete Sponsor
       %h1 Edit #{@sponsor.name}
 
 = render 'form', sponsor: @sponsor

--- a/app/views/staff/sponsors/index.html.haml
+++ b/app/views/staff/sponsors/index.html.haml
@@ -1,0 +1,26 @@
+.row
+  &nbsp;
+
+.row
+  .col-md-8
+    %h3
+      Sponsors
+      %span.badge= @sponsors.count
+  .col-md-4.text-right
+    = link_to "+ New Sponsor", new_event_staff_sponsor_path(current_event), class: "btn btn-success btn-sm"
+.row
+  .col-md-12
+    %table#program-sessions.datatable.table.table-striped
+      %tr
+        %th Name
+        %th Tier
+        %th Published
+        %th Url
+        %th Alt Title
+        %th Edit
+        %th.hidden
+
+      %tbody
+        = render @sponsors
+
+%hr

--- a/app/views/staff/sponsors/new.html.haml
+++ b/app/views/staff/sponsors/new.html.haml
@@ -1,0 +1,6 @@
+.row
+  .col-md-12
+    .page-header.clearfix
+      %h1 New Event Sponsor
+
+= render partial: 'form', locals: { sponsor: @sponsor }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
       resources :tracks, except: [:show]
       resource :website, only: [:new, :create, :edit, :update]
       resources :pages, only: [:index, :new, :create, :edit, :update]
+      resources :sponsors, only: [:index, :new, :create, :edit, :update]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,7 @@ Rails.application.routes.draw do
       resources :tracks, except: [:show]
       resource :website, only: [:new, :create, :edit, :update]
       resources :pages, only: [:index, :new, :create, :edit, :update]
-      resources :sponsors, only: [:index, :new, :create, :edit, :update]
+      resources :sponsors, only: [:index, :new, :create, :edit, :update, :destroy]
     end
   end
 

--- a/db/migrate/20220413201907_create_sponsors.rb
+++ b/db/migrate/20220413201907_create_sponsors.rb
@@ -1,0 +1,15 @@
+class CreateSponsors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sponsors do |t|
+      t.belongs_to :event, foreign_key: true
+
+      t.string :name
+      t.string :tier
+      t.boolean :published
+      t.string :url
+      t.string :other_title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_153740) do
+ActiveRecord::Schema.define(version: 2022_04_13_201907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -180,6 +180,18 @@ ActiveRecord::Schema.define(version: 2022_04_12_153740) do
     t.index ["user_id"], name: "index_speakers_on_user_id"
   end
 
+  create_table "sponsors", force: :cascade do |t|
+    t.bigint "event_id"
+    t.string "name"
+    t.string "tier"
+    t.boolean "published"
+    t.string "url"
+    t.string "other_title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_sponsors_on_event_id"
+  end
+
   create_table "taggings", force: :cascade do |t|
     t.bigint "proposal_id"
     t.string "tag"
@@ -285,5 +297,6 @@ ActiveRecord::Schema.define(version: 2022_04_12_153740) do
 
   add_foreign_key "pages", "websites"
   add_foreign_key "session_formats", "events"
+  add_foreign_key "sponsors", "events"
   add_foreign_key "websites", "events"
 end

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :sponsor do
+    
+  end
+end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Sponsor, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
🟡 Still needs a test suite, but here is a description of the changes so far. 

# Description of Change
This PR seeks to add a Sponsor model to a CFP Event.
The PR also handles most of the CRUD for said Sponsor Model
 
# Reason for Change
Both RubyConf sites and RailsConf sites allow admins to submit Sponsors that are displayed on the conference websites. In order for the CFP app to be able to recreate the conference websites, it will need to be able to store event Sponsors. 

# Changes
Here is a quick break down of the sponsor model that needs to be recreated

| **Conference sites Sponsor Model** | **New CFP Sponsor Model (this PR)** |
| ------------------------------------  | -------------------------------------- |
| name | name
|  tier | tier
|  published | published
|  score
|  url | url 
|  other_title | other_title
|  description | 
|  offer_headline |
|  offer_url |
|  banner_url | 

In addition the conference Sponsor model has the ability to have three logos hang off it. (primary_logo, footer_logo, banner_ad). This PR doesn't seek to accomplish that yet. 

The links/buttons/path to interact with the Sponsors resource has been positioned inside the website sub nav. 
For the time being any event organizers will have the ability to perform any resourceful action on an Event Sponsor. 

# Minor
It made sense to me to link sponsors to Events. I figured it might be valuable to ask if folks thought that was the correct call.  I can see an argument even though the reason we are adding them to the CFP application is to display them on the Website. I wasn't 100% sure if that was the right call so I figured I would bring that up here. 

I will setup some tests for this tomorrow. But for the time being I thought it would be valuable to get it out. 

# Who doesn't love a preview

![Sponsor CRUD](https://user-images.githubusercontent.com/71521423/163336949-3ea3d74a-1360-4c37-bf90-2dab2ce96e9c.gif)
Preview made locally with imported production data


https://link.to/task_tracker_card
