### PR TITLE
Organizer Configures Website Domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,8 +55,13 @@ class ApplicationController < ActionController::Base
 
   def current_website
     @current_website ||= begin
-      event = current_event || Event.find_by(slug: params[:slug])
-      event.website
+      if current_event
+        current_event.website
+      elsif params[:slug]
+        Website.joins(:event).find_by(events: { slug: params[:slug] })
+      else
+        Website.domain_match(request.domain).order(created_at: :desc).first
+      end
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,12 +1,18 @@
 class PagesController < ApplicationController
+  before_action :require_website_page, only: :show
+
   def current_styleguide
   end
 
   def show
-    page = current_website.pages.published.find_by!(slug: params[:page])
-    @body = page.published_body
+    @body = @page.published_body
     render layout: "themes/#{current_website.theme}"
-  rescue ActiveRecord::RecordNotFound
-    redirect_to '/404'
+  end
+
+  private
+
+  def require_website_page
+    @page = current_website && current_website.pages.published.find_by(slug: params[:page])
+    redirect_to not_found_path and return unless @page
   end
 end

--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -6,7 +6,7 @@ class Staff::WebsitesController < Staff::ApplicationController
   def new; end
 
   def create
-    @website.save
+    @website.update(website_params)
 
     flash[:success] = "Website was successfully created."
     redirect_to event_staff_path(current_event)
@@ -15,7 +15,7 @@ class Staff::WebsitesController < Staff::ApplicationController
   def edit; end
 
   def update
-    @website.save
+    @website.update(website_params)
 
     flash[:success] = "Website was successfully updated."
     redirect_to event_staff_path(current_event)
@@ -29,5 +29,9 @@ class Staff::WebsitesController < Staff::ApplicationController
 
   def authorize_website
     authorize(@website)
+  end
+
+  def website_params
+    params.require(:website).permit(:domains)
   end
 end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -3,6 +3,10 @@ class Website < ApplicationRecord
   has_many :pages
 
   DEFAULT = 'default'.freeze
+
+  def self.domain_match(domain)
+    where(arel_table[:domains].matches("%#{(domain)}"))
+  end
 end
 
 # == Schema Information

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -16,7 +16,7 @@
               = current_website.event.decorate.date_range
         %nav#main-nav
           - current_website.pages.published.each do |page|
-            = link_to page.name, page_path(current_website.event, page)
+            = link_to page.name, page_path(params[:slug], page)
           .social-links
             %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
             %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -1,5 +1,8 @@
 = simple_form_for website, url: :event_staff_website do |f|
   .row
+    %fieldset.col-md-6
+      = f.input :domains
+  .row
     .col-sm-12
       = submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
       = link_to "Cancel", event_staff_path(current_event), {:class=>"cancel-form pull-right btn btn-danger"}

--- a/config/initializers/domain_constraint.rb
+++ b/config/initializers/domain_constraint.rb
@@ -1,0 +1,5 @@
+class DomainConstraint
+  def matches?(request)
+    Website.domain_match(request.domain).exists?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,9 +145,12 @@ Rails.application.routes.draw do
   end
 
   get '/current-styleguide', :to => 'pages#current_styleguide'
-  get '/404', :to => 'errors#not_found'
+  get '/404', :to => 'errors#not_found', as: :not_found
   get '/422', :to => 'errors#unacceptable'
   get '/500', :to => 'errors#internal_error'
 
-  get '/:slug/:page', :to => 'pages#show', as: :page
+  constraints DomainConstraint.new do
+    get ':page', :to => 'pages#show'
+  end
+  get '/(:slug)/:page', :to => 'pages#show', as: :page
 end

--- a/db/migrate/20220414014639_add_domains_to_websites.rb
+++ b/db/migrate/20220414014639_add_domains_to_websites.rb
@@ -1,0 +1,5 @@
+class AddDomainsToWebsites < ActiveRecord::Migration[6.1]
+  def change
+    add_column :websites, :domains, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_114245) do
+ActiveRecord::Schema.define(version: 2022_04_14_014639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -281,6 +281,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_114245) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "theme", default: "default", null: false
+    t.string "domains"
     t.index ["event_id"], name: "index_websites_on_event_id"
   end
 

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
+include ActionView::Helpers::SanitizeHelper
 feature "Website Configuration" do
   let(:event) { create(:event) }
   let(:organizer) { create(:organizer, event: event) }
 
-  scenario "Organizer configures a new website for event" do
+  scenario "Organizer creates a new website for event" do
     login_as(organizer)
 
     visit event_path(event)
@@ -15,17 +16,33 @@ feature "Website Configuration" do
     expect(event.website).to be_present
   end
 
-  scenario "Organizer configures an existing website for event" do
+  scenario "Organizer configures domain for an existing website for event" do
     website = create(:website, event: event)
-    login_as(organizer)
+    home_page = create(:page, website: website)
 
+    visit("/#{home_page.slug}")
+
+    expect(current_path).to eq(not_found_path)
+
+    login_as(organizer)
     visit event_path(website.event)
     within('.navbar') { click_on("Website") }
 
     expect(page).to have_content("Edit Website")
 
+    fill_in('Domains', with: 'www.example.com')
     click_on("Save")
 
     expect(page).to have_content("Website was successfully updated")
+
+    logout
+
+    visit("/#{home_page.slug}")
+
+    expect(page).to have_content(strip_tags(home_page.published_body))
+
+    click_on(home_page.name)
+
+    expect(current_path).to eq('/home')
   end
 end

--- a/spec/models/website_spec.rb
+++ b/spec/models/website_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Event do
+  describe '.domain_match' do
+    it 'returns website that match a domain' do
+      rubyconf = create(:website, domains: 'www.rubyconf.org')
+      _otherconf = create(:website)
+      expect(Website.domain_match('rubyconf.org')).to contain_exactly(rubyconf)
+    end
+    it 'returns website that match one of multiple domains' do
+      rubyconf = create(:website, domains: 'www.rubyconf.org,www.rubyconf.com')
+      _otherconf = create(:website)
+      expect(Website.domain_match('rubyconf.com')).to contain_exactly(rubyconf)
+    end
+  end
+end


### PR DESCRIPTION
Organizer Configures Website Domain

Reason for Change
=================
This PR will hopefully allow a url like `railsconf.org/about` to still route correctly to the latest railsconf site about page without having the event slug in the url. 

Changes
=======
- adds Website#domains field and DomainConstraint to allow for website
  matching without using slugs in the urls
- adds Website.domain_match for SQL matching of domains
- changes page_path route to have optional slug param so that navigation
  paths keep the slug out of url when using custom domain
- redirects to 404 page when website or page are not found

[Miro Card](https://miro.com/app/board/uXjVOA-0gUs=/?moveToWidget=3458764523048559109&cot=14)
[PR Review App](https://cfp-app-flagrant-websit-lr4e6n.herokuapp.com)