### PR TITLE
Organizer Selects Landing Page 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,8 +55,13 @@ class ApplicationController < ActionController::Base
 
   def current_website
     @current_website ||= begin
-      event = current_event || Event.find_by(slug: params[:slug])
-      event.website
+      if current_event
+        current_event.website
+      elsif params[:slug]
+        Website.joins(:event).find_by(events: { slug: params[:slug] })
+      else
+        Website.domain_match(request.domain).order(created_at: :desc).first
+      end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,9 +60,22 @@ class ApplicationController < ActionController::Base
       elsif params[:slug]
         Website.joins(:event).find_by(events: { slug: params[:slug] })
       else
-        Website.domain_match(request.domain).order(created_at: :desc).first
+        older_domain_website || latest_domain_website
       end
     end
+  end
+
+  def older_domain_website
+    @older_domain_website ||=
+      domain_websites.find_by(events: { slug: params[:domain_page_or_slug] })
+  end
+
+  def latest_domain_website
+    @latest_domain_website ||= domain_websites.first
+  end
+
+  def domain_websites
+    Website.domain_match(request.domain).joins(:event).order(created_at: :desc)
   end
 
   def set_current_event(event_id)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,12 +1,18 @@
 class PagesController < ApplicationController
+  before_action :require_website_page, only: :show
+
   def current_styleguide
   end
 
   def show
-    page = current_website.pages.published.find_by!(slug: params[:page])
-    @body = page.published_body
+    @body = @page.published_body
     render layout: "themes/#{current_website.theme}"
-  rescue ActiveRecord::RecordNotFound
-    redirect_to '/404'
+  end
+
+  private
+
+  def require_website_page
+    @page = current_website && current_website.pages.published.find_by(slug: params[:page])
+    redirect_to not_found_path and return unless @page
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
-  before_action :require_website_page, only: :show
+  before_action :require_website, only: :show
+  before_action :require_page, only: :show
 
   def current_styleguide
   end
@@ -11,8 +12,27 @@ class PagesController < ApplicationController
 
   private
 
-  def require_website_page
-    @page = current_website && current_website.pages.published.find_by(slug: params[:page])
-    redirect_to not_found_path and return unless @page
+  def require_website
+    redirect_to not_found_path and return unless current_website
+  end
+
+  def require_page
+    @page = current_website.pages.published.find_by(page_conditions)
+    unless @page
+      @body = "Page Not Found"
+      render layout: "themes/#{current_website.theme}" and return
+    end
+  end
+
+  def page_conditions
+    landing_page_request? ? { landing: true } : { slug: page_param }
+  end
+
+  def page_param
+    params[:domain_page_or_slug] || params[:page]
+  end
+
+  def landing_page_request?
+    page_param.nil? || @older_domain_website
   end
 end

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -18,7 +18,7 @@ class Staff::PagesController < Staff::ApplicationController
   def create
     if @page.update(page_params)
       flash[:success] = "#{@page.name} Page was successfully created."
-      redirect_to event_staff_pages_path(current_event, @page)
+      redirect_to event_staff_pages_path(current_event)
     else
       render :new
     end
@@ -29,7 +29,7 @@ class Staff::PagesController < Staff::ApplicationController
   def update
     if @page.update(page_params)
       flash[:success] = "#{@page.name} Page was successfully updated."
-      redirect_to event_staff_pages_path(current_event, @page)
+      redirect_to event_staff_pages_path(current_event)
     else
       render :edit
     end
@@ -40,7 +40,13 @@ class Staff::PagesController < Staff::ApplicationController
   def publish
     @page.update(published_body: @page.unpublished_body)
     flash[:success] = "#{@page.name} Page was successfully published."
-    redirect_to event_staff_pages_path(current_event, @page)
+    redirect_to event_staff_pages_path(current_event)
+  end
+
+  def promote
+    Page.promote(@page)
+    flash[:success] = "#{@page.name} Page was successfully promoted."
+    redirect_to event_staff_pages_path(current_event)
   end
 
   private

--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -6,7 +6,7 @@ class Staff::WebsitesController < Staff::ApplicationController
   def new; end
 
   def create
-    @website.save
+    @website.update(website_params)
 
     flash[:success] = "Website was successfully created."
     redirect_to event_staff_path(current_event)
@@ -15,7 +15,7 @@ class Staff::WebsitesController < Staff::ApplicationController
   def edit; end
 
   def update
-    @website.save
+    @website.update(website_params)
 
     flash[:success] = "Website was successfully updated."
     redirect_to event_staff_path(current_event)
@@ -29,5 +29,9 @@ class Staff::WebsitesController < Staff::ApplicationController
 
   def authorize_website
     authorize(@website)
+  end
+
+  def website_params
+    params.require(:website).permit(:domains)
   end
 end

--- a/app/helpers/website_helper.rb
+++ b/app/helpers/website_helper.rb
@@ -1,0 +1,5 @@
+module WebsiteHelper
+  def website_event_slug
+    params[:slug] || (@older_domain_website && @older_domain_website.event.slug)
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -8,6 +8,13 @@ class Page < ApplicationRecord
   def to_param
     slug
   end
+
+  def self.promote(page)
+    transaction do
+      page.website.pages.update(landing: false)
+      page.update(landing: true)
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -3,6 +3,10 @@ class Website < ApplicationRecord
   has_many :pages
 
   DEFAULT = 'default'.freeze
+
+  def self.domain_match(domain)
+    where(arel_table[:domains].matches("%#{(domain)}"))
+  end
 end
 
 # == Schema Information

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -30,4 +30,8 @@ class PagePolicy < ApplicationPolicy
   def publish?
     new?
   end
+
+  def promote?
+    new?
+  end
 end

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -11,12 +11,12 @@
           %a#menu-toggle{ href: "#"}
           %div
             %h1
-              = current_website.event.name
+              = link_to(current_website.event.name, landing_path(website_event_slug))
             %h4
               = current_website.event.decorate.date_range
         %nav#main-nav
           - current_website.pages.published.each do |page|
-            = link_to page.name, page_path(params[:slug], page)
+            = link_to page.name, page_path(website_event_slug, page)
           .social-links
             %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
             %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -16,7 +16,7 @@
               = current_website.event.decorate.date_range
         %nav#main-nav
           - current_website.pages.published.each do |page|
-            = link_to page.name, page_path(current_website.event, page)
+            = link_to page.name, page_path(params[:slug], page)
           .social-links
             %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
             %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -2,6 +2,9 @@
   %td= link_to(page.name, edit_event_staff_page_path(current_event, page))
   %td= link_to(page.slug, edit_event_staff_page_path(current_event, page))
   %td
+    - if page.landing?
+      %span.glyphicon.glyphicon-ok
+  %td
     = link_to("Preview",
       preview_event_staff_page_path(current_event, page),
       class: 'btn btn-primary')
@@ -10,3 +13,9 @@
       method: :patch,
       data: { confirm: "Are you sure you want to publish?" },
       class: 'btn btn-primary')
+    - unless page.landing?
+      = link_to("Promote",
+        promote_event_staff_page_path(current_event, page),
+        method: :patch,
+        data: { confirm: "Are you sure you want to promote #{page.name} to be the landing page?" },
+        class: 'btn btn-primary')

--- a/app/views/staff/pages/index.html.haml
+++ b/app/views/staff/pages/index.html.haml
@@ -1,10 +1,11 @@
 .row
-  .col-md-8
-    %h3
-      Website Page
-      %span.badge= @pages.count
-  .col-md-4.text-right
-    = link_to "+ New Page", new_event_staff_page_path(current_event), class: "btn btn-success btn-sm"
+  .col-md-12
+    %header
+      %h3
+        Website Pages
+        = link_to "New Page",
+          new_event_staff_page_path(current_event),
+          class: "btn btn-primary btn-sm pull-right"
 .row
   .col-md-12
     %table.datatable.table.table-striped
@@ -12,6 +13,8 @@
         %tr
           %th Name
           %th Slug
+          %th Landing Page
+          %th Actions
       %tbody
         = render @pages
 %hr

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -1,5 +1,8 @@
 = simple_form_for website, url: :event_staff_website do |f|
   .row
+    %fieldset.col-md-6
+      = f.input :domains
+  .row
     .col-sm-12
       = submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
       = link_to "Cancel", event_staff_path(current_event), {:class=>"cancel-form pull-right btn btn-danger"}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,5 @@ Rails.application.configure do
 
   config.time_zone = ENV.fetch('TIMEZONE') { 'Pacific Time (US & Canada)' }
   config.action_cable.url = 'ws://localhost:3000/cable'
+  config.hosts.clear
 end

--- a/config/initializers/domain_constraint.rb
+++ b/config/initializers/domain_constraint.rb
@@ -1,0 +1,5 @@
+class DomainConstraint
+  def matches?(request)
+    Website.domain_match(request.domain).exists?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,9 +145,12 @@ Rails.application.routes.draw do
   end
 
   get '/current-styleguide', :to => 'pages#current_styleguide'
-  get '/404', :to => 'errors#not_found'
+  get '/404', :to => 'errors#not_found', as: :not_found
   get '/422', :to => 'errors#unacceptable'
   get '/500', :to => 'errors#internal_error'
 
-  get '/:slug/:page', :to => 'pages#show', as: :page
+  constraints DomainConstraint.new do
+    get ':page', :to => 'pages#show'
+  end
+  get '/(:slug)/:page', :to => 'pages#show', as: :page
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,12 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  constraints DomainConstraint.new do
+    get '/', to: 'pages#show'
+    get '/:domain_page_or_slug', to: 'pages#show'
+    get '/:slug/:page', to: 'pages#show'
+  end
+
   root 'home#show'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   mount ActionCable.server => '/cable'
@@ -113,6 +120,7 @@ Rails.application.routes.draw do
         member do
           get :preview
           patch :publish
+          patch :promote
         end
       end
     end
@@ -149,8 +157,6 @@ Rails.application.routes.draw do
   get '/422', :to => 'errors#unacceptable'
   get '/500', :to => 'errors#internal_error'
 
-  constraints DomainConstraint.new do
-    get ':page', :to => 'pages#show'
-  end
-  get '/(:slug)/:page', :to => 'pages#show', as: :page
+  get '/(:slug)', to: 'pages#show', as: :landing
+  get '/(:slug)/:page', to: 'pages#show', as: :page
 end

--- a/db/migrate/20220414014639_add_domains_to_websites.rb
+++ b/db/migrate/20220414014639_add_domains_to_websites.rb
@@ -1,0 +1,5 @@
+class AddDomainsToWebsites < ActiveRecord::Migration[6.1]
+  def change
+    add_column :websites, :domains, :string
+  end
+end

--- a/db/migrate/20220415014232_add_landing_to_pages.rb
+++ b/db/migrate/20220415014232_add_landing_to_pages.rb
@@ -1,0 +1,5 @@
+class AddLandingToPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pages, :landing, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_114245) do
+ActiveRecord::Schema.define(version: 2022_04_14_014639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -281,6 +281,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_114245) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "theme", default: "default", null: false
+    t.string "domains"
     t.index ["event_id"], name: "index_websites_on_event_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_14_014639) do
+ActiveRecord::Schema.define(version: 2022_04_15_014232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 2022_04_14_014639) do
     t.text "unpublished_body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "landing", default: false, null: false
     t.index ["website_id"], name: "index_pages_on_website_id"
   end
 

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
+include ActionView::Helpers::SanitizeHelper
 feature "Website Configuration" do
   let(:event) { create(:event) }
   let(:organizer) { create(:organizer, event: event) }
 
-  scenario "Organizer configures a new website for event" do
+  scenario "Organizer creates a new website for event" do
     login_as(organizer)
 
     visit event_path(event)
@@ -15,17 +16,33 @@ feature "Website Configuration" do
     expect(event.website).to be_present
   end
 
-  scenario "Organizer configures an existing website for event" do
+  scenario "Organizer configures domain for an existing website for event" do
     website = create(:website, event: event)
-    login_as(organizer)
+    home_page = create(:page, website: website)
 
+    visit("/#{home_page.slug}")
+
+    expect(current_path).to eq(not_found_path)
+
+    login_as(organizer)
     visit event_path(website.event)
     within('.navbar') { click_on("Website") }
 
     expect(page).to have_content("Edit Website")
 
+    fill_in('Domains', with: 'www.example.com')
     click_on("Save")
 
     expect(page).to have_content("Website was successfully updated")
+
+    logout
+
+    visit("/#{home_page.slug}")
+
+    expect(page).to have_content(strip_tags(home_page.published_body))
+
+    click_on(home_page.name)
+
+    expect(current_path).to eq('/home')
   end
 end

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -50,7 +50,7 @@ feature "Website Page Management" do
     login_as(organizer)
 
     visit page_path(slug: event.slug, page: home_page.slug)
-    expect(current_path).to eq('/404')
+    expect(page).to have_content("Page Not Found")
     visit event_staff_pages_path(event)
     accept_confirm { click_on('Publish') }
 
@@ -66,6 +66,18 @@ feature "Website Page Management" do
     visit page_path(slug: event.slug, page: home_page.slug)
     expect(page).to have_content('Home Content')
     within('#main-nav') { expect(page).to have_content(home_page.name) }
+  end
+
+  scenario "Organizer changes a website landing page", :js do
+    create(:page, name: 'Announcement', slug: 'announcement', landing: true)
+    home_page = create(:page, name: 'Home', slug: 'home')
+    login_as(organizer)
+
+    visit event_staff_pages_path(event)
+    accept_confirm { click_on('Promote') }
+
+    expect(page).to have_content('Home Page was successfully promoted.')
+    expect(home_page.reload).to be_landing
   end
 
 end

--- a/spec/features/website/page_viewing_spec.rb
+++ b/spec/features/website/page_viewing_spec.rb
@@ -1,13 +1,59 @@
 require 'rails_helper'
 
-feature "Public Page Viewing" do
+feature 'Public Page Viewing' do
   let(:event) { create(:event) }
   let!(:website) { create(:website, event: event) }
 
-  scenario "Public views a published website page" do
+  scenario 'Public views a published website page' do
     home_page = create(:page, published_body: 'Home Content')
     visit page_path(slug: event.slug, page: home_page.slug)
+
     expect(page).to have_content('Home Content')
     within('#main-nav') { expect(page).to have_content(home_page.name) }
+  end
+
+  scenario 'Public views the landing page of website' do
+    create(:page, published_body: 'Home Content', landing: true)
+    visit landing_path(slug: event.slug)
+
+    expect(page).to have_content('Home Content')
+  end
+
+  scenario 'Public views the landing page from custom domain' do
+    website.update(domains: 'www.example.com')
+    create(:page, published_body: 'Home Content', landing: true)
+    visit root_path
+
+    expect(page).to have_content('Home Content')
+  end
+
+  scenario 'Public views the landing page for an older website on custom domain' do
+    website.update(domains: 'www.example.com')
+    old_home_page = create(:page, published_body: 'Old Website', landing: true)
+
+    new_website = create(:website, domains: 'www.example.com')
+    new_home_page = create(:page,
+                           website: new_website,
+                           published_body: 'New Website',
+                           landing: true)
+
+    visit root_path
+    expect(page).to have_content('New Website')
+
+    click_on(new_home_page.name)
+    expect(page).to have_content('New Website')
+
+    visit landing_path(slug: website.event.slug)
+    expect(page).to have_content('Old Website')
+
+    click_on(old_home_page.name)
+    expect(page).to have_content('Old Website')
+  end
+
+  scenario 'Public gets not found message for wrong path on subdomain' do
+    website.update(domains: 'www.example.com')
+
+    visit landing_path(slug: website.event.slug)
+    expect(page).to have_content("Page Not Found")
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Page do
+  describe '.promote' do
+    let!(:page) { create(:page, website: create(:website)) }
+    it 'promotes the website page to be the landing page' do
+      Page.promote(page)
+      expect(page).to be_landing
+    end
+
+    it 'demotes the other website pages from being the landing page' do
+      other_page = create(:page, landing: true)
+      expect { Page.promote(page) }
+        .to change { page.landing }.from(false).to(true)
+        .and change { other_page.reload.landing }.from(true).to(false)
+    end
+
+    it 'does not affect other website landing pages' do
+      other_page = create(:page, landing: true, website: create(:website))
+      expect { Page.promote(page) }
+        .to change { page.landing }.from(false).to(true)
+      expect(other_page.reload).to be_landing
+    end
+  end
+end

--- a/spec/models/website_spec.rb
+++ b/spec/models/website_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Event do
+  describe '.domain_match' do
+    it 'returns website that match a domain' do
+      rubyconf = create(:website, domains: 'www.rubyconf.org')
+      _otherconf = create(:website)
+      expect(Website.domain_match('rubyconf.org')).to contain_exactly(rubyconf)
+    end
+    it 'returns website that match one of multiple domains' do
+      rubyconf = create(:website, domains: 'www.rubyconf.org,www.rubyconf.com')
+      _otherconf = create(:website)
+      expect(Website.domain_match('rubyconf.com')).to contain_exactly(rubyconf)
+    end
+  end
+end

--- a/spec/models/website_spec.rb
+++ b/spec/models/website_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Event do
+describe Website do
   describe '.domain_match' do
     it 'returns website that match a domain' do
       rubyconf = create(:website, domains: 'www.rubyconf.org')

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -12,7 +12,17 @@ RSpec.describe PagePolicy do
     CurrentEventContext.new(user, event)
   end
 
-  permissions :index?, :new?, :create?, :edit?, :update?, :show?, :preview?, :publish? do
+  permissions(
+    :index?,
+    :new?,
+    :create?,
+    :edit?,
+    :update?,
+    :show?,
+    :preview?,
+    :publish?,
+    :promote?
+  )  do
     it 'allows organizers for event' do
       expect(subject).to permit(pundit_user(organizer))
     end


### PR DESCRIPTION
Organizer Selects Landing Page 
Reason for Change
=================
This PR allows an organizer to select which page will serve as the landing page for the website. The thought is that when an event is first announced there will likely be a different page to serve as the landing page than when registration starts and the conference begins. 

Moreover, this PR hopefully improves some of the routing complexity needed in order to host multiple websites using custom domains without also getting tangled in the home page for CFP app itself. One challenge the PR hopefully addresses is a possible conflict between routes like `railsconf.org/about` which should route to the latest Railsconf about page and `railsconf.org/railsconf-2021` which should route to the landing page for an older Railsconf site. Since these two urls have similar signatures the route param was renamed to `:domain_page_or_slug` for clarity. 

Changes
=======
- adds Page#landing to track the landing page for website
- adds Page.promote for changing the landing page of a website
- improves routing to prevent conflicts with cfp_app home page with the
  landing pages of domain requested event websites
- refines domain constrained routing using :domain_page_or_slug param to
  allow for older domain website landing pages to be accessed
- displays "Page Not Found" message when website page is not found
- corrects routing to index page when creating or updating page
- adds feature specs to help enforce routing logic around domain website
  requests

[Change the default home page](https://miro.com/app/board/uXjVOA-0gUs=/?moveToWidget=3458764523284975192&cot=14)
[Loom Demo](https://www.loom.com/share/f0b02efbdc97484e9fcda01b619441ba)