### PR TITLE
Nullify a ProgramSession's TimeSlot

### DIFF
--- a/app/models/program_session.rb
+++ b/app/models/program_session.rb
@@ -39,7 +39,7 @@ class ProgramSession < ApplicationRecord
   belongs_to :proposal
   belongs_to :track
   belongs_to :session_format
-  has_one :time_slot
+  has_one :time_slot, dependent: :nullify
   has_many :speakers, -> { order(:created_at)}
 
   accepts_nested_attributes_for :speakers

--- a/spec/models/program_session_spec.rb
+++ b/spec/models/program_session_spec.rb
@@ -280,5 +280,14 @@ describe ProgramSession do
       expect(Speaker.all).to include(proposal.speakers.first)
       expect(proposal.speakers.first.program_session_id).to eq(nil)
     end
+
+    it "removes program_session_id from time_slot if session was scheduled" do
+      proposal = create(:proposal, :with_speaker)
+      ps = create(:program_session, proposal_id: proposal.id)
+      ts = create(:time_slot_with_program_session, program_session: ps)
+      ps.destroy
+
+      expect(ts.reload.program_session_id).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Reason for Change
=================
Recently, we had a speaker cancel their presentation, but the session had already been scheduled in the app.

In prod, I deleted the `ProgramSession` using the dedicated button in the UI to do so, but then got some errors when trying to view the schedule.

This was because there was still a `TimeSlot` referencing the deleted `ProgramSession`.

Changes
=======
When deleting a `ProgramSession`, nullify the `program_session_id` on the related `TimeSlot` if applicable.

Also cleaned up some specs while I was in there.