### PR TITLE
Wireframe website layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,3 +81,7 @@ jobs:
 
       # Run the tests
       - run: bin/rake
+
+      # Store failed js spec artifacts
+      - store_artifacts:
+          path: tmp/screenshots

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -565,4 +565,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.11
+   2.3.12

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -47,6 +47,7 @@
 @import "modules/buttons";
 @import "modules/calendar";
 @import "modules/coderay";
+@import "modules/code-mirror";
 @import "modules/dashboard";
 @import "modules/data_tables";
 @import "modules/discussions";

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -73,3 +73,4 @@
 @import "modules/tooltips";
 @import "modules/widgets";
 @import "modules/teammates";
+@import "modules/staff-website-page";

--- a/app/assets/stylesheets/modules/_code-mirror.scss
+++ b/app/assets/stylesheets/modules/_code-mirror.scss
@@ -1,0 +1,34 @@
+.CodeMirror {
+  /* Bootstrap Settings */
+  box-sizing: border-box;
+  margin: 0;
+  font: inherit;
+  overflow: auto;
+  font-family: inherit;
+  display: block;
+  width: 100%;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1.42857143;
+  color: #555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075); /* Bootstrap 3 */
+  box-shadow: none; /* Bootstrap 4 */
+  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+  /* Code Mirror Settings */
+  font-family: monospace;
+  position: relative;
+  overflow: hidden;
+}
+
+.CodeMirror-focused {
+  /* Bootstrap Settings */
+  border-color: #66afe9;
+  outline: 0;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(102, 175, 233, .6); /* Bootstrap 3 */
+  box-shadow: 0 0 0 .2rem rgba(0, 123, 255, .25); /* Bootstrap 4 */
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+}

--- a/app/assets/stylesheets/modules/_staff-website-page.scss
+++ b/app/assets/stylesheets/modules/_staff-website-page.scss
@@ -1,14 +1,28 @@
 #page-preview-wrapper {
-  height: 700px;
-  width: 50%;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-#live-preview-page {
-  border: 1px solid black;
-  width: 99%;
-  height: 620px;
-  overflow: scroll;
+.preview-flex {
+  display: flex;
+  width: 100%;
+
+  .resize {
+    flex-grow: 1;
+    display: flex;
+    margin: 10px;
+    padding: 10px;
+    overflow: scroll;
+    resize: both;
+    border: 1px solid black;
+    height: 70vh;
+    .inner {
+      flex-grow: 1;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      display: block;
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/_staff-website-page.scss
+++ b/app/assets/stylesheets/modules/_staff-website-page.scss
@@ -1,0 +1,14 @@
+#page-preview-wrapper {
+  height: 700px;
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#live-preview-page {
+  border: 1px solid black;
+  width: 99%;
+  height: 620px;
+  overflow: scroll;
+}

--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -24,40 +24,20 @@ html {
 
 body {
   color: $text;
+  padding: 0;
+  margin: 0;
   background: var(--body_background_color);
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 150%;
-  padding: 50px 0;
-  height: 100vh;
-}
-
-/* Hide scrollbar for Chrome, Safari and Opera */
-::-webkit-scrollbar {
-  display: none;
+  overflow: scroll;
 }
 
 .hidden {
   display: none;
 }
 
-#main-default {
-  width: 95%;
-  max-width: 1070px;
-  height: calc(100vh - 100px);
-  margin: 0 auto;
-  border: 1px solid $black;
-  overflow: scroll;
-  box-shadow: inset 0 0 0 1px $black; /** covers the weird border-radius 1px gap **/
-  position: relative;
-}
-
 #content {
   background-color: var(--main_content_background);
-  margin-left: 178px;
-  padding: 50px 20px 20px 50px;
-  position: relative;
-  height: calc(100vh - 100px);
+  padding: 0 20px 0 20px;
+  margin-top: 100px;
 }
 
 p {
@@ -85,13 +65,6 @@ ul li {
   padding: 0 0 12px 12px;
 }
 
-#main-notice {
-  padding: 15px 10px;
-  position: relative;
-  margin-bottom: 20px;
-  text-align: center;
-  border: 1px solid $black;
-}
 
 .btn {
   display: inline-block;
@@ -103,17 +76,4 @@ ul li {
 
 @media screen and (max-width: 900px) and (orientation: portrait),
   (max-width: 823px) and (orientation: landscape) {
-    body {
-      padding: 8px;
-    }
-    #main-default {
-      width: auto;
-      height: 97%;
-      display: block;
-    }
-    #content {
-      padding: 76px 10px 10px 10px;
-      margin: 0 0 0 0;
-      height: calc(100vh - 32px);
-    }
 }

--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -1,6 +1,7 @@
 @import url('https://rsms.me/inter/inter-ui.css');
 @import 'colors';
 @import 'nav';
+@import 'footer';
 @import 'schedule';
 
 :root {

--- a/app/assets/stylesheets/themes/default/colors.scss
+++ b/app/assets/stylesheets/themes/default/colors.scss
@@ -1,6 +1,7 @@
 $grey: #494644 !default;
 $grey-light: #C4C4C4 !default;
 $grey-lightest: #F5F5F5 !default;
+$grey-logo: #E6E6E6 !default;
 $text: $grey !default;
 $black: #000000;
 $red: #C04F45 !default;

--- a/app/assets/stylesheets/themes/default/colors.scss
+++ b/app/assets/stylesheets/themes/default/colors.scss
@@ -4,3 +4,4 @@ $black: #000000;
 $red: #C04F45 !default;
 $gold: #ecd192 !default;
 $divider: #E0D2C7 !default;
+$divider-light: rgba(0, 0, 0, .1);

--- a/app/assets/stylesheets/themes/default/colors.scss
+++ b/app/assets/stylesheets/themes/default/colors.scss
@@ -1,4 +1,6 @@
 $grey: #494644 !default;
+$grey-light: #C4C4C4 !default;
+$grey-lightest: #F5F5F5 !default;
 $text: $grey !default;
 $black: #000000;
 $red: #C04F45 !default;

--- a/app/assets/stylesheets/themes/default/footer.scss
+++ b/app/assets/stylesheets/themes/default/footer.scss
@@ -1,0 +1,68 @@
+footer {
+  display: grid;
+  width: 100%;
+  border-top: 1px solid $divider-light;
+  grid-template-columns: 1fr 1fr;
+  padding: 20px 30px 35px;
+
+  .footer-event-details {
+    border-bottom: 1px solid $divider-light;
+    padding-bottom: 20px;
+    .logo-container {
+      margin-bottom:  20px;
+
+      .website-event-logo {
+        height: 36px;
+        width: 36px;
+        background-color: $grey-logo;
+        border-radius: 3px;
+        margin-bottom: 0;
+      }
+      a {
+        text-decoration: none;
+        font-weight: 700;
+      }
+    }
+
+    .footer-social-links {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      a {
+        width: 30px;
+        height: 30px;
+        display: inline-block;
+        margin: 0 6px 0 0;
+        &:hover {
+          transform: translateX(2px);
+        }
+      }
+      .twitter-link {
+        background: asset-url('themes/default/twitter-icon.svg') center center no-repeat;
+      }
+      .facebook-link {
+        background: asset-url('themes/default/fb-icon.svg') center center no-repeat;
+      }
+      .instagram-link {
+        background: asset-url('themes/default/instagram-icon.svg') center center no-repeat;
+      }
+    }
+  }
+
+  .footer-event-links {
+    align-self: end;
+    border-bottom: 1px solid $divider-light;
+    padding-bottom: 20px;
+
+    a {
+      display: inline-block;
+      margin-right: 10px;
+      text-decoration: none;
+
+      &:hover {
+        transform: translateX(2px) translateY(-2px);
+      }
+    }
+
+  }
+}

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -6,7 +6,6 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  border-bottom: 1px solid black;
   background: var(--nav_background_color);
   color: var(--nav_text_color);
 

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -1,40 +1,41 @@
 #main-header {
   position: fixed;
-  height: calc(100vh - 100px);
-  width: 176px;
-  border-right: 1px solid $black;
+  top: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border-bottom: 1px solid black;
   background: var(--nav_background_color);
   color: var(--nav_text_color);
 
   #header-logo-container {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    width: 100%;
-    div {
-      text-align: center;
+    margin-left: 10px;
+
+    .website-event-logo {
+      display: block;
+      height: 36px;
+      width: 36px;
+      margin-right: 5px;
+      background: lightgray;
+      border-radius: 3px;
     }
   }
 
   #main-nav {
+    margin-right: 15px;
+    display: flex;
+    gap: 25px;
+
     a {
-      height: 50px;
-      padding: 0 0 0 40px;
-      line-height: 50px;
-      font-size: 14px;
       display: block;
-      border-bottom: 1px solid $divider;
-      background-color: var(--nav_background_color);
       color: var(--nav_text_color);
       &:hover {
         color: var(--nav_link_hover);
         transform: translateX(2px);
-      }
-      &.register-link {
-        color: $red;
-        &:hover {
-          color: $gold;
-        }
       }
     }
   }
@@ -45,68 +46,18 @@
     &#menu-toggle {
       display: none;
     }
-    &#header-logo-area {
-      border: 1px solid $black;
-      padding: 0;
-      width: 170px;
-      height: 170px;
-      position: relative;
-    }
-  }
-
-  .social-links {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    border-bottom: 1px solid $divider;
-    a {
-      width: 16px;
-      height: 16px;
-      display: inline-block;
-      margin: 0 5px 0 0;
-      border-bottom: none!important;
-      &:hover {
-        transform: translateX(2px);
-      }
-    }
-    .twitter-link {
-      background: asset-url('themes/default/twitter-icon.svg') center center no-repeat;
-    }
-    .facebook-link {
-      background: asset-url('themes/default/fb-icon.svg') center center no-repeat;
-    }
-    .instagram-link {
-      background: asset-url('themes/default/instagram-icon.svg') center center no-repeat;
-    }
   }
 }
 
 @media screen and (max-width: 900px) and (orientation: portrait),
   (max-width: 823px) and (orientation: landscape) {
     #main-header{
-      width: calc(100% - 32px);
-      border-top: none;
-      border-left: none;
-      border-bottom: 1px solid black;
-      height: 72px;
       z-index: 20;
+      flex-direction: column;
+      align-items: start;
 
       #header-logo-container {
-        flex-direction: row;
-        align-items: center;
-        height: 72px;
-        div {
-          padding: 0 0 0 10px;
-          text-align: left;
-        }
-        h1, h4 {
-          margin: 0px 0px 0px 0px;
-        }
-      }
-
-      #header-logo-area {
-        height: 72px!important;
-        width: 72px!important;
+        white-space: nowrap;
       }
 
       a {
@@ -116,7 +67,6 @@
           height: 64px;
           position: absolute;
           right: 0;
-          top: 8px;
           background: image-url('themes/default/menu.svg') center center no-repeat;
           transition: none;
           &.menu-toggle--opened {
@@ -124,33 +74,10 @@
           }
         }
       }
-
-      .social-links {
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        padding: 0;
-
-        a {
-          height: 56px;
-          display: block;
-          width: auto;
-          margin: 0;
-          border-right: 1px solid $divider;
-          &:last-child {
-            border-right: none;
-          }
-        }
-      }
     }
     #main-nav {
-      z-index: 9;
-      border-right: 1px solid $black;
-      border-left: 1px solid $black;
-      width: 100%;
-      display: block;
-      border-top: 1px solid $divider;
-      height: calc(100vh - 104px);
-      transform: translate(0, calc(-100vh - 70px));
+      margin-left: 10px;
+      display: none!important;
       transition: transform .35s ease-in-out;
       a {
         padding: 0;
@@ -158,11 +85,10 @@
         line-height: 36px;
         display: block;
         text-indent: 8px;
-        border-bottom: 1px solid $divider;
       }
       &.menu-mobile--opened {
+        display: block!important;
         transform: translate(0, 0)!important;
       }
     }
-
   }

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -19,7 +19,7 @@
       height: 36px;
       width: 36px;
       margin-right: 5px;
-      background: lightgray;
+      background: $grey-logo;
       border-radius: 3px;
     }
   }

--- a/app/assets/stylesheets/themes/default/schedule.scss
+++ b/app/assets/stylesheets/themes/default/schedule.scss
@@ -21,15 +21,15 @@
           font-size: 24px;
           font-weight: 700;
           display: block;
-          opacity: .15;
+          color: $grey-light;
           width: 100%;
           margin: auto;
           text-align: center;
           text-decoration: none;
           &:hover {
-            opacity: 1;
-            box-shadow: 0 3px white,
-                        0 6px black;
+            color: $black;
+            box-shadow: 0 7px var(--main_content_background),
+                        0 10px $black;
             transition: all 300ms;
           }
         }
@@ -47,12 +47,16 @@
   grid-template-columns: 160px 1fr;
   grid-template-areas: "time-duration program-sessions";
   gap: 10px;
-  padding: 10px 0;
-  border-top: .5px solid $divider-light;
+  border-top: 1px solid $divider-light;
 
+  &:last-child {
+    border-bottom: 1px solid $divider-light;
+    margin-bottom: 50px;
+  }
   .schedule-duration {
     grid-area: time-duration;
     text-align: right;
+    padding-top: 20px;
     width: 100%;
 
     .session-end-time::before {
@@ -63,40 +67,70 @@
   .schedule-grid {
     display: grid;
     grid-area: program-sessions;
-    grid-template-columns: 1fr 1fr;
-    gap: 10px
+    grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 
-
   .schedule-grid-cell {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    border: 1px solid black;
-    width: 98%;
-    padding: 5px;
-
-    .schedule-session-detail {
-      display: flex;
-      justify-content: space-between;
+    border-right: 1px solid $divider-light;
+    padding: 10px 15px;
+    display: grid;
+    align-items: center;
+    gap: 5px;
+    grid-template-rows: 30px auto 15px 30px;
+    grid-template-areas: "track"
+                         "title"
+                         "room"
+                         "speaker";
+    &:only-child {
+      border-right: none;
     }
 
-    .schedule-session-title {
-      font-size: 1.2em;
-      font-weight: 600;
+    &:nth-child(4n+4) {
+      border-right: none;
     }
 
-    .schedule-session-description {
-      font-size: .9em;
+    &:nth-child(n+5) {
+      border-top: 1px solid $divider-light!important;
     }
 
     .session-track {
-      border: 1px solid $black;
-      font-size: .9em;
-      padding: 2px 5px;
+      grid-area: track;
+      display: flex;
+      justify-content: center;
+      border-radius: 3px;
+      align-items: center;
+      font-size: 12px;
+      background-color: $grey-lightest;
+      padding: 5px 7px;
       width: fit-content;
-      display: inline-block;
-      margin-bottom: 10px;
+    }
+
+    .schedule-session-title {
+      grid-area: title;
+      font-size: 21px;
+      font-weight: 500;
+      text-decoration: underline;
+    }
+
+    .schedule-room {
+      display: flex;
+      align-items: center;
+      grid-area: room;
+
+      .room-icon {
+        margin-right: 4px;
+        display: inline-block;
+        height: 15px;
+        aspect-ratio: 1 / 1;
+        border-radius: 100%;
+        background-color: $grey-light;
+      }
+    }
+
+    .schedule-presenter {
+      font-size: 16px;
+      font-weight: 500;
+      grid-area: speaker;
     }
   }
 }
@@ -105,30 +139,44 @@
 
 @media screen and (max-width: 900px) and (orientation: portrait),
   (max-width: 823px) and (orientation: landscape) {
-    .schedule-block-container {
+
+    .schedule-page-wrapper {
       grid-template-columns: 1fr;
+      grid-template-areas: "sub-nav"
+                           "schedule";
+      align-items: center;
+      justify-content: center;
+    }
+
+    .sub-nav {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .schedule-block-container {
+      grid-template-rows: 30px 1fr;
+      grid-template-columns: 1fr;
+      grid-template-areas: "time-duration"
+                           "program-sessions";
+      border-top: none;
 
       .schedule-duration {
-        width: auto;
-        border-right: none;
-        margin: 0 5px 5px ;
-        span {
-          display: inline;
-          text-align: right;
-        }
+        grid-area: time-duration;
+        text-align: left;
+
         .session-end-time::before {
           content: "-";
         }
       }
 
       .schedule-grid-cell {
-        border: 1px solid black;
         padding: 5px 5px;
         margin: 0 5px;
         width: auto;
-        .schedule-session-detail {
-          display: flex;
-          justify-content: space-between;
+
+        &:nth-child(n) {
+          border: 1px solid $divider-light;
         }
       }
 

--- a/app/assets/stylesheets/themes/default/schedule.scss
+++ b/app/assets/stylesheets/themes/default/schedule.scss
@@ -26,7 +26,7 @@
           margin: auto;
           text-align: center;
           text-decoration: none;
-          &:hover {
+          &:hover, &.selected {
             color: $black;
             box-shadow: 0 7px var(--main_content_background),
                         0 10px $black;

--- a/app/assets/stylesheets/themes/default/schedule.scss
+++ b/app/assets/stylesheets/themes/default/schedule.scss
@@ -1,26 +1,72 @@
+.schedule-page-wrapper {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  grid-template-rows: 45px 1fr;
+  grid-template-areas: ". sub-nav"
+                       "schedule schedule";
+
+  .sub-nav {
+    grid-area: sub-nav;
+    display: flex;
+    align-items: center;
+    ul {
+      margin: 0;
+      padding: 0;
+      display: flex;
+      gap: 30px;
+      li {
+        margin: 0;
+        padding: 0;
+        a {
+          font-size: 24px;
+          font-weight: 700;
+          display: block;
+          opacity: .15;
+          width: 100%;
+          margin: auto;
+          text-align: center;
+          text-decoration: none;
+          &:hover {
+            opacity: 1;
+            box-shadow: 0 3px white,
+                        0 6px black;
+            transition: all 300ms;
+          }
+        }
+      }
+    }
+  }
+}
+
+#schedule-container {
+  grid-area: schedule;
+}
+
 .schedule-block-container {
   display: grid;
-  grid-template-columns: 14% 1fr;
+  grid-template-columns: 160px 1fr;
+  grid-template-areas: "time-duration program-sessions";
   gap: 10px;
-  border-bottom: 5px solid black;
-  padding: 5px 5px;
+  padding: 10px 0;
+  border-top: .5px solid $divider-light;
 
   .schedule-duration {
+    grid-area: time-duration;
+    text-align: right;
     width: 100%;
-    padding: 0 5px 0 0;
-    border-right: 1px solid black;
-    margin: 0 5px 0 0;
-    span {
-      display: block;
-      text-align: right;
-    }
-    .session-start-time {
-      font-size: 1.1em;
-    }
+
     .session-end-time::before {
       content: "-";
     }
   }
+
+  .schedule-grid {
+    display: grid;
+    grid-area: program-sessions;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px
+  }
+
 
   .schedule-grid-cell {
     display: flex;
@@ -52,11 +98,6 @@
       display: inline-block;
       margin-bottom: 10px;
     }
-  }
-  .schedule-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 10px
   }
 }
 

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -9,7 +9,7 @@ class Staff::PagesController < Staff::ApplicationController
   end
 
   def show
-    @body = @page.unpublished_body
+    @body = @page.unpublished_body || ""
     render template: 'pages/show', layout: "themes/#{current_website.theme}"
   end
 
@@ -29,7 +29,7 @@ class Staff::PagesController < Staff::ApplicationController
   def update
     if @page.update(page_params)
       flash[:success] = "#{@page.name} Page was successfully updated."
-      redirect_to edit_event_staff_page_path(current_event, @page)
+      redirect_to event_staff_pages_path(current_event)
     else
       render :edit
     end
@@ -52,7 +52,7 @@ class Staff::PagesController < Staff::ApplicationController
   private
 
   def set_page
-    @page = if params[:id]
+    @page = if params[:id] && (params[:id] != Page::BLANK_SLUG)
               current_website.pages.find_by(slug: params[:id])
             else
               current_website.pages.build

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -29,7 +29,7 @@ class Staff::PagesController < Staff::ApplicationController
   def update
     if @page.update(page_params)
       flash[:success] = "#{@page.name} Page was successfully updated."
-      redirect_to event_staff_pages_path(current_event)
+      redirect_to edit_event_staff_page_path(current_event, @page)
     else
       render :edit
     end

--- a/app/decorators/staff/time_slot_decorator.rb
+++ b/app/decorators/staff/time_slot_decorator.rb
@@ -130,10 +130,6 @@ class Staff::TimeSlotDecorator < Draper::Decorator
     object.session_description || object.description
   end
 
-  def shortened_display_description(char_length = 100)
-    display_description.truncate(char_length)
-  end
-
   def room
     object.room_name
   end

--- a/app/helpers/website_schedule_helper.rb
+++ b/app/helpers/website_schedule_helper.rb
@@ -1,9 +1,10 @@
 module WebsiteScheduleHelper
 
   def schedule_for_day(schedule, day_number)
-    schedule.select { |program_session| program_session[:conference_day] == day_number }
-            .sort_by {|program_session| program_session[:start_time] }
-            .group_by {|program_session| program_session[:start_time] }
+    schedule.select { |time_slot| time_slot[:conference_day] == day_number }
+            .filter { |time_slot| !time_slot[:title].blank? || time_slot.program_session }
+            .sort_by {|time_slot| time_slot[:start_time] }
+            .group_by {|time_slot| time_slot[:start_time] }
             .values
   end
 end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus'
 
 export default class extends Controller {
-  static targets = ['input']
+  static targets = ['input', 'preview']
 
   initialize () {
     this.defaults = {
@@ -16,6 +16,13 @@ export default class extends Controller {
         ' bold italic backcolor | alignleft aligncenter ' +
         ' alignright alignjustify | bullist numlist outdent indent | ' +
         ' removeformat | code | help'
+        ,
+        init_instance_callback: function(editor) {
+          editor.on('input', function(e) {
+            var preview = document.getElementById('page-preview');
+            preview.contentWindow.location.reload(true);
+          });
+        }
     }
   }
 

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from 'stimulus'
+import CodeMirror from 'codemirror/lib/codemirror.js'
+import 'codemirror/lib/codemirror.css'
+import 'codemirror/mode/htmlmixed/htmlmixed.js'
 
 export default class extends Controller {
-  static targets = ['input', 'preview']
+  static targets = ['htmlContent', 'wysiwygContent', 'wysiwyg', 'html']
 
   initialize () {
     this.defaults = {
@@ -12,26 +15,61 @@ export default class extends Controller {
         'searchreplace visualblocks code fullscreen',
         'insertdatetime media table paste code help wordcount'
       ],
-        toolbar: 'undo redo | formatselect | ' +
-        ' bold italic backcolor | alignleft aligncenter ' +
-        ' alignright alignjustify | bullist numlist outdent indent | ' +
-        ' removeformat | code | help'
-        ,
-        init_instance_callback: function(editor) {
-          editor.on('input', function(e) {
-            var preview = document.getElementById('page-preview');
-            preview.contentWindow.location.reload(true);
-          });
-        }
+      toolbar: 'undo redo | formatselect | ' +
+      ' bold italic backcolor | alignleft aligncenter ' +
+      ' alignright alignjustify | bullist numlist outdent indent | ' +
+      ' removeformat | code | help',
+      valid_elements: '*[*]',
+      forced_root_block : '',
+      init_instance_callback: function(editor) {
+        editor.on('input', function(e) {
+          var preview = document.getElementById('page-preview');
+          preview.contentWindow.document.getElementById("content").innerHTML = e.target.innerHTML;
+        });
+      }
     }
   }
 
+  editHtml(e) {
+    e.preventDefault();
+    this.wysiwygTarget.classList.add("hidden");
+    this.htmlTarget.classList.remove("hidden");
+    this.htmlContentTarget.disabled = false;
+    var editor = CodeMirror.fromTextArea(this.htmlContentTarget, {
+      mode: "htmlmixed",
+      lineWrapping: true,
+    });
+    editor.setValue(this.wysiwygEditor.getContent());
+    for (var i=0;i<editor.lineCount();i++) { editor.indentLine(i); }
+    editor.on('change', function(e) {
+      var preview = document.getElementById('page-preview');
+      preview.contentWindow.document.getElementById("content").innerHTML = e.getValue();
+    })
+  }
+
+  wysiwyg(e) {
+    e.preventDefault();
+    this.wysiwygTarget.classList.remove("hidden");
+    this.htmlTarget.classList.add("hidden");
+    this.htmlContentTarget.disabled = true;
+    this.wysiwygEditor.setContent(this.htmlEditor.getValue());
+    this.htmlEditor.toTextArea();
+  }
+
+  get wysiwygEditor() {
+    return tinyMCE.activeEditor;
+  }
+
+  get htmlEditor() {
+    return document.querySelector('.CodeMirror').CodeMirror;
+  }
+
   connect () {
-    let config = Object.assign({ target: this.inputTarget }, this.defaults)
+    let config = Object.assign({ target: this.wysiwygContentTarget }, this.defaults)
     tinyMCE.init(config)
   }
 
   disconnect () {
-    tinymce.remove()
+    tinyMCE.remove()
   }
 }

--- a/app/javascript/controllers/sub_nav_controller.js
+++ b/app/javascript/controllers/sub_nav_controller.js
@@ -22,6 +22,8 @@ export default class extends Controller {
 
   updateDisplay(e) {
     e.preventDefault()
+    document.querySelector('.selected')?.classList.remove('selected')
+    e.target.classList.add('selected')
     this.displayedIdValue = e.target.getAttribute('displayedId')
   }
 

--- a/app/javascript/controllers/sub_nav_controller.js
+++ b/app/javascript/controllers/sub_nav_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
 
   updateDisplay(e) {
     e.preventDefault()
-    this.displayedIdValue = e.target.parentNode.getAttribute('displayedId')
+    this.displayedIdValue = e.target.getAttribute('displayedId')
   }
 
   displayedIdValueChanged() {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,7 +15,6 @@
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-console.log('Hello World from Webpacker')
 // Support component names relative to this directory:
 var componentRequireContext = require.context("components", true);
 var ReactRailsUJS = require("react_ujs");

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,8 +5,10 @@ class Page < ApplicationRecord
 
   validates :name, :slug, presence: true
 
+  BLANK_SLUG = "0"
+
   def to_param
-    slug
+    slug.presence || BLANK_SLUG
   end
 
   def self.promote(page)

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -34,7 +34,6 @@
           = link_to page.name, page_path(website_event_slug, page)
         = link_to "Schedule", schedule_path(current_website.event)
 
-
     :javascript
       var openEl = document.getElementById('menu-toggle');
       var mobileNavEl = document.getElementById('main-nav');

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -18,6 +18,22 @@
         = link_to "Schedule", schedule_path(current_website.event)
     #content
       =yield
+    %footer
+      .footer-event-details
+        .logo-container
+          .website-event-logo
+          = link_to(current_website.event.name, landing_path(website_event_slug))
+        .footer-social-links
+          %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
+          %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }
+          %a.instagram-link{ href: 'https://instagram.com/rubyconf', target: '_blank' }
+
+
+      .footer-event-links
+        - current_website.pages.published.each do |page|
+          = link_to page.name, page_path(website_event_slug, page)
+        = link_to "Schedule", schedule_path(current_website.event)
+
 
     :javascript
       var openEl = document.getElementById('menu-toggle');

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -5,6 +5,7 @@
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     = stylesheet_link_tag current_website.theme, media: 'all'
     = javascript_pack_tag "application"
+    %script{src: "https://cdn.tailwindcss.com" }
   %body
     %header#main-header
       %div#header-logo-container

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -6,24 +6,18 @@
     = stylesheet_link_tag current_website.theme, media: 'all'
     = javascript_pack_tag "application"
   %body
-    %main#main-default
-      %header#main-header
-        %div#header-logo-container
-          %a#menu-toggle{ href: "#"}
-          %div
-            %h1
-              = link_to(current_website.event.name, landing_path(website_event_slug))
-            %h4
-              = current_website.event.decorate.date_range
-        %nav#main-nav
-          - current_website.pages.published.each do |page|
-            = link_to page.name, page_path(website_event_slug, page)
-          .social-links
-            %a.twitter-link{ href: 'https://twitter.com/rubyconf', target: '_blank' }
-            %a.facebook-link{ href: 'https://facebook.com/rubyconf2021', target: '_blank' }
-            %a.instagram-link{ href: 'https://instagram.com/rubyconf', target: '_blank' }
-      #content
-        =yield
+    %header#main-header
+      %div#header-logo-container
+        %a#menu-toggle{ href: "#"}
+        .website-event-logo
+        %h1
+          = link_to(current_website.event.name, landing_path(website_event_slug))
+      %nav#main-nav
+        - current_website.pages.published.each do |page|
+          = link_to page.name, page_path(website_event_slug, page)
+        = link_to "Schedule", schedule_path(current_website.event)
+    #content
+      =yield
 
     :javascript
       var openEl = document.getElementById('menu-toggle');

--- a/app/views/programs/show.html.haml
+++ b/app/views/programs/show.html.haml
@@ -1,4 +1,4 @@
-%div
+%div{ data: { 'controller': 'sub-nav', 'sub-nav-displayed-id-value': 'sessions' } }
   %h3
     Program
   %p
@@ -9,37 +9,33 @@
       %small
         5
     %li.program_sessions
-      %a{:href=>'#'}
-        Talks
-        %small
-          = @program_sessions.regular_sessions.count
+      %a{ href: "#", displayedId: 'sessions', data: { action: 'click->sub-nav#updateDisplay' } }
+        = "Talks #{@program_sessions.regular_sessions.count}"
     %li.program-workshops
-      %a{:href=>'#'}
-        Workshops  Talks
-        %small
-          = @program_sessions.workshops.count
+      %a{ href: "#", displayedId: 'workshops', data: { action: 'click->sub-nav#updateDisplay' } }
+        = "Workshops #{@program_sessions.workshops.count}"
 
-#sessions
-  #regular_sessions
-    %nav#tracks-nav
-      %strong
-        Tracks
-      %ul
-        - current_website.event.tracks.each do |track|
-          %li
-            %a.track{ href: "#" }
-              = track.name
-        %li.back-to-top
-          %a{ href: "#" }
-            &uparrow; Back To Top
+  #sessions{ data: { 'sub-nav-target': 'hideable' } }
+    #regular_sessions
+      %nav#tracks-nav
+        %strong
+          Tracks
+        %ul
+          - current_website.event.tracks.each do |track|
+            %li
+              %a.track{ href: "#" }
+                = track.name
+          %li.back-to-top
+            %a{ href: "#" }
+              &uparrow; Back To Top
+      %h2
+        Talks
+      - @program_sessions.regular_sessions.each do |program_session|
+        %div
+          = render program_session
+  #workshops{ data: { 'sub-nav-target': 'hideable' } }
     %h2
-      Talks
-    - @program_sessions.regular_sessions.each do |program_session|
+      Workshops
+    - @program_sessions.workshops.each do |program_session|
       %div
         = render program_session
-#workshops
-  %h2
-    Workshops
-  - @program_sessions.workshops.each do |program_session|
-    %div
-      = render program_session

--- a/app/views/schedule/_program_session.html.haml
+++ b/app/views/schedule/_program_session.html.haml
@@ -10,6 +10,3 @@
     %span.schedule-room
       = image_tag('themes/default/pin-icon.svg')
       = program_session.room
-  - if !program_session.shortened_display_description.blank?
-    .schedule-session-description
-      = program_session.shortened_display_description

--- a/app/views/schedule/_program_session.html.haml
+++ b/app/views/schedule/_program_session.html.haml
@@ -4,9 +4,8 @@
       = program_session.display_track_name
   .schedule-session-title
     = program_session.display_title
-  .schedule-session-detail
-    %span.schedule-presenter
-      =  program_session.display_presenter
-    %span.schedule-room
-      = image_tag('themes/default/pin-icon.svg')
-      = program_session.room
+  .schedule-room
+    %span.room-icon
+    = program_session.room
+  .schedule-presenter
+    =  program_session.display_presenter

--- a/app/views/schedule/_schedule_block.html.haml
+++ b/app/views/schedule/_schedule_block.html.haml
@@ -4,10 +4,6 @@
       = program_sessions.first.start_time
     %span.session-end-time
       = program_sessions.first.end_time
-  - if program_sessions.size == 1
-    = render partial: 'program_session', locals: { program_session: program_sessions.first }
-  - else
-    .schedule-grid
-      - program_sessions.each do |program_session|
-        - next if program_session.display_title.blank?
-        = render partial: 'program_session', locals: { program_session: program_session }
+  .schedule-grid
+    - program_sessions.each do |program_session|
+      = render partial: 'program_session', locals: { program_session: program_session }

--- a/app/views/schedule/show.html.haml
+++ b/app/views/schedule/show.html.haml
@@ -1,20 +1,16 @@
 
-%div{ data: { 'controller': 'sub-nav', 'sub-nav-displayed-id-value': 'schedule-day-one' } }
-  %section#hero.schedule-hero
-    %nav
-      %ul
-        %li
-          %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-one', data: { action: 'click->sub-nav#updateDisplay' } }
-            %strong
-              = current_event.conference_day_in_words(1)
-        %li
-          %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-two', data: { action: 'click->sub-nav#updateDisplay' } }
-            %strong
-              = current_event.conference_day_in_words(2)
-        %li
-          %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-three', data: { action: 'click->sub-nav#updateDisplay' } }
-            %strong
-              = current_event.conference_day_in_words(3)
+.schedule-page-wrapper{ data: { 'controller': 'sub-nav', 'sub-nav-displayed-id-value': 'schedule-day-one' } }
+  %nav.sub-nav
+    %ul
+      %li
+        %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-one', data: { action: 'click->sub-nav#updateDisplay' } }
+          = current_event.conference_date(1).strftime("%B %e")
+      %li
+        %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-two', data: { action: 'click->sub-nav#updateDisplay' } }
+          = current_event.conference_date(2).strftime("%B %e")
+      %li
+        %a#schedule-day-link.selected{ href: "#", displayedId: 'schedule-day-three', data: { action: 'click->sub-nav#updateDisplay' } }
+          = current_event.conference_date(3).strftime("%B %e")
 
   #schedule-container
     #schedule-day-one{ data: { 'sub-nav-target': 'hideable' }}

--- a/app/views/schedule/show.html.haml
+++ b/app/views/schedule/show.html.haml
@@ -3,13 +3,13 @@
   %nav.sub-nav
     %ul
       %li
-        %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-one', data: { action: 'click->sub-nav#updateDisplay' } }
+        %a#schedule-day-link.selected{ href: "#", displayedId: 'schedule-day-one', data: { action: 'click->sub-nav#updateDisplay' } }
           = current_event.conference_date(1).strftime("%B %e")
       %li
         %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-two', data: { action: 'click->sub-nav#updateDisplay' } }
           = current_event.conference_date(2).strftime("%B %e")
       %li
-        %a#schedule-day-link.selected{ href: "#", displayedId: 'schedule-day-three', data: { action: 'click->sub-nav#updateDisplay' } }
+        %a#schedule-day-link{ href: "#", displayedId: 'schedule-day-three', data: { action: 'click->sub-nav#updateDisplay' } }
           = current_event.conference_date(3).strftime("%B %e")
 
   #schedule-container

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -1,13 +1,20 @@
 = simple_form_for [current_event, :staff, page] do |f|
-  .row
+  .row{ data: { controller: :editor } }
     %fieldset.col-md-6
       = f.input :name
       = f.input :slug
       = f.input :unpublished_body,
         as: :text,
-        wrapper_html: { data: { controller: :editor } },
-        input_html: { data: { "editor-target": 'input' } }
+        wrapper_html: { data: { "controller": "page-preview", "page-preview-count-value": "0" } },
+        input_html: { data: { "editor-target": "input" } }
+    %fieldset#page-preview-wrapper.col-md-6
+      %h4 Preview Page
+      #live-preview-page.col-lg-6
+        %iframe{  src: "#{event_staff_page_path(current_event, @page)}",
+                  width: "100%",
+                  style: "height:1000vh;",
+                  id: "page-preview" }
   .row
     .col-sm-12
-      = submit_tag("Save", class: "pull-right btn btn-success", type: "submit")
-      = link_to "Cancel", event_staff_pages_path(current_event), {:class=>"cancel-form pull-right btn btn-danger"}
+      = submit_tag("Save", class: "btn btn-success", type: "submit")
+      = link_to "Cancel", event_staff_pages_path(current_event), {:class=>"cancel-form btn btn-danger"}

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -1,15 +1,23 @@
 = simple_form_for [current_event, :staff, page] do |f|
-  .row{ data: { controller: :editor } }
-    %fieldset.col-md-6
-      = f.input :name
-      = f.input :slug
-      = f.input :unpublished_body,
-        as: :text,
-        wrapper_html: { data: { "controller": "page-preview", "page-preview-count-value": "0" } },
-        input_html: { data: { "editor-target": "input" } }
-    %fieldset#page-preview-wrapper.col-md-6
-      %h4 Preview Page
-      #live-preview-page.col-lg-6
+  .preview-flex{ data: { controller: :editor } }
+    .resize
+      .inner
+        = f.input :name
+        = f.input :slug
+        %div{ data: { controller: :editor } }
+          %div{ data: { "editor-target": :wysiwyg } }
+            = f.input :unpublished_body,
+              as: :text,
+              input_html: { data: { "editor-target": :wysiwygContent } }
+            = link_to("Edit HTML", '#', { data: { action: "click->editor#editHtml" } })
+          %div{ data: { "editor-target": :html }, class: 'hidden' }
+            = f.input :unpublished_body,
+              as: :text,
+              input_html: { data: { "editor-target": :htmlContent }, disabled: true }
+            = link_to("WYSIWYG", '#', { data: { action: "click->editor#wysiwyg" } })
+    .resize
+      #page-preview-wrapper
+        %h4 Preview Page
         %iframe{  src: "#{event_staff_page_path(current_event, @page)}",
                   width: "100%",
                   style: "height:1000vh;",

--- a/app/views/staff/pages/preview.html.haml
+++ b/app/views/staff/pages/preview.html.haml
@@ -3,14 +3,20 @@
     .page-header.clearfix
       %h1 Preview #{@page.name} Page
 
-%iframe{
-  src: "#{event_staff_page_path(current_event, @page)}",
-  width: "100%",
-  style: "height:90vh;",
-  id: "page-preview"}
+.row
+  .col-md-12
+    #live-preview-page.col-md-12
+      %iframe{
+        src: "#{event_staff_page_path(current_event, @page)}",
+        width: "100%",
+        style: "height:90vh;",
+        id: "page-preview"}
 
 .row
   .col-sm-12
+    = link_to("Preview Full Page",
+      event_staff_page_path(current_event, @page),
+      class: 'btn btn-primary')
     = link_to("Publish",
       publish_event_staff_page_path(current_event, @page),
       method: :patch,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@babel/preset-react": "^7.14.5",
     "@rails/webpacker": "^5.4.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "codemirror": "^5.65.3",
     "core-js": "^3.12.1",
     "glob-parent": "^5.1.2",
     "node-forge": "^0.10.0",

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -41,7 +41,7 @@ feature "Website Configuration" do
 
     expect(page).to have_content(strip_tags(home_page.published_body))
 
-    click_on(home_page.name)
+    click_on(home_page.name, match: :first)
 
     expect(current_path).to eq('/home')
   end

--- a/spec/features/website/page_viewing_spec.rb
+++ b/spec/features/website/page_viewing_spec.rb
@@ -40,13 +40,13 @@ feature 'Public Page Viewing' do
     visit root_path
     expect(page).to have_content('New Website')
 
-    click_on(new_home_page.name)
+    click_on(new_home_page.name, match: :first)
     expect(page).to have_content('New Website')
 
     visit landing_path(slug: website.event.slug)
     expect(page).to have_content('Old Website')
 
-    click_on(old_home_page.name)
+    click_on(old_home_page.name, match: :first)
     expect(page).to have_content('Old Website')
   end
 

--- a/spec/features/website/schedule_spec.rb
+++ b/spec/features/website/schedule_spec.rb
@@ -43,14 +43,16 @@ feature "dynamic website schedule page" do
     visit schedule_path(event)
 
     expect(page).to have_content(time_slot.title)
-    click_on(event.conference_date(2).strftime("%A, %B %d - Day 2"))
+    click_on(event.conference_date(2).strftime("%B %e"))
 
+    expect(page)
+      .to have_link(event.conference_date(2).strftime("%B %e"), class: "selected")
     expect(page).to_not have_content(time_slot.title)
     time_slot.update(conference_day: 2)
 
     visit schedule_path(event)
     expect(page).to_not have_content(time_slot.title)
-    click_on(event.conference_date(2).strftime("%A, %B %d - Day 2"))
+    click_on(event.conference_date(2).strftime("%B %e"))
 
     expect(page).to have_content(time_slot.title)
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,12 @@ RSpec.configure do |config|
   config.before(:all) do
     FactoryBot.reload
   end
+
+  config.after(:each, js: true) do |example|
+    if example.exception
+      save_timestamped_screenshot(Capybara.page)
+    end
+  end
 end
 
 Capybara.register_driver :chrome do |app|
@@ -72,3 +78,11 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.javascript_driver = ENV['CHROME'] ? :chrome : :headless_chrome
+
+def save_timestamped_screenshot(page)
+  timestamp = Time.zone.now.strftime("%Y_%m_%d-%H_%M_%S")
+  filename = "#{method_name}-#{timestamp}.png"
+  screenshot_path = Rails.root.join("tmp", "screenshots", filename)
+
+  page.save_screenshot(screenshot_path)
+end

--- a/spec/support/helpers/form_helpers.rb
+++ b/spec/support/helpers/form_helpers.rb
@@ -1,10 +1,11 @@
 module Features
   module FormHelpers
     def fill_in_tinymce(resource, field, content)
-      within_frame("#{resource}_#{field}_ifr") do
+      iframe_id = "#{resource}_#{field}_ifr"
+      within_frame(iframe_id) do
         editor = page.find_by_id('tinymce')
         editor.native.send_keys(content)
-      end
+      end if page.has_css?("##{iframe_id}")
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,6 +1917,11 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
+codemirror@^5.65.3:
+  version "5.65.3"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.3.tgz#2d029930d5a293bc5fb96ceea64654803c0d4ac7"
+  integrity sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"


### PR DESCRIPTION
[Author content & preview content seamlessly](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523892494937&cot=14)

Reason for Change
=================
Stolen from Miro Card...

> As a content creator, imagine I'm building a webpage from scratch. I need to be able to see what the content and the style will look like. I want to be able to save my work and have it appear as it will on the site when I publish it. I want to be able to see-saw between writing content and markup and seeing the results without interruption. I also want to be able to see the content as it will appear in various browser and device configurations.

Included in this PR is also a first pass on wiring up the new wire frame designs created by Gina Valdez.

Changes
=======
- Adds ability to edit html for page using CodeMirror for syntax
  highlighting and indenting
- Adds realtime changes to preview while editing content
- Adds ability to adjust the preview iframe window size
- Adds link to preview the unpublished body in full size
- Reworks the event website component/layout to align with Gina's designs
- Modifies the website schedule page to align with Gina Valdez template design
- Wires up early website footer component
- Wires up program sub nav

[Author content & preview content seamlessly](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523892494937&cot=14)