### PR TITLE
Use Images In Content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'paper_trail'
 gem 'sendgrid-ruby'
 
 group :production do
+  gem 'aws-sdk-s3'
   gem 'rack-timeout', '~> 0.5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,22 @@ GEM
       rake (>= 10.4, < 14.0)
     autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.580.0)
+    aws-sdk-core (3.130.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.56.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.113.2)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -235,6 +251,7 @@ GEM
     interception (0.5)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jmespath (1.6.1)
     jquery-datatables-rails (3.4.0)
       actionpack (>= 3.1)
       jquery-rails
@@ -492,6 +509,7 @@ DEPENDENCIES
   actionview-encoded_mail_to
   active_model_serializers (~> 0.10.0)
   annotate
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap

--- a/app/assets/stylesheets/modules/_staff-website-page.scss
+++ b/app/assets/stylesheets/modules/_staff-website-page.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 }
 
 .preview-flex {
@@ -24,5 +25,10 @@
       border: 0;
       display: block;
     }
+  }
+  iframe {
+    border: 0;
+    width: 100%;
+    height: 100vh;
   }
 }

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -1,0 +1,14 @@
+class ImageUploadsController < ApplicationController
+  skip_forgery_protection
+  before_action :require_user
+
+  def create
+    blob = ActiveStorage::Blob.create_after_upload!(
+      io: params[:file],
+      filename: params[:file].original_filename,
+      content_type: params[:file].content_type
+    )
+
+    render json: {location: url_for(blob)}, content_type:  "text/html"
+  end
+end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -1,6 +1,5 @@
 import { Controller } from 'stimulus'
 import CodeMirror from 'codemirror/lib/codemirror.js'
-import 'codemirror/lib/codemirror.css'
 import 'codemirror/mode/htmlmixed/htmlmixed.js'
 
 export default class extends Controller {
@@ -18,13 +17,20 @@ export default class extends Controller {
       toolbar: 'undo redo | formatselect | ' +
       ' bold italic backcolor | alignleft aligncenter ' +
       ' alignright alignjustify | bullist numlist outdent indent | ' +
-      ' removeformat | code | help',
+      ' removeformat | image code | help',
       valid_elements: '*[*]',
       forced_root_block : '',
+      images_upload_url: '/image_uploads',
+      images_file_types: 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp,svg',
+      relative_urls: false,
       init_instance_callback: function(editor) {
         editor.on('input', function(e) {
           var preview = document.getElementById('page-preview');
           preview.contentWindow.document.getElementById("content").innerHTML = e.target.innerHTML;
+        });
+        editor.on('change', function(e) {
+          var preview = document.getElementById('page-preview');
+          preview.contentWindow.document.getElementById("content").innerHTML = e.target.getContent();
         });
       }
     }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,4 +20,5 @@ var componentRequireContext = require.context("components", true);
 var ReactRailsUJS = require("react_ujs");
 ReactRailsUJS.useContext(componentRequireContext);
 
+import '../stylesheets/application.scss'
 import "controllers"

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,0 +1,1 @@
+@import 'codemirror/lib/codemirror.css'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,7 @@
     = stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css', media: 'all'
     = stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600"
 
+    = stylesheet_pack_tag "application", media: 'all'
     = javascript_pack_tag "application"
 
     = javascript_include_tag 'https://www.gstatic.com/charts/loader.js'

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -18,10 +18,8 @@
     .resize
       #page-preview-wrapper
         %h4 Preview Page
-        %iframe{  src: "#{event_staff_page_path(current_event, @page)}",
-                  width: "100%",
-                  style: "height:1000vh;",
-                  id: "page-preview" }
+        %iframe{ src: "#{event_staff_page_path(current_event, @page)}",
+                 id: "page-preview" }
   .row
     .col-sm-12
       = submit_tag("Save", class: "btn btn-success", type: "submit")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,2 @@
+ActiveStorage::Engine.config.active_storage
+  .content_types_to_serve_as_binary.delete "image/svg+xml"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,7 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :image_uploads, only: :create
   resource :public_comments, only: [:create], controller: :comments, type: 'PublicComment'
   resource :internal_comments, only: [:create], controller: :comments, type: 'InternalComment'
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket
+amazon:
+  service: S3
+  access_key_id: <%= ENV.fetch("AWS_ACCESS_KEY_ID", "") %>
+  secret_access_key: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY", "")  %>
+  region: <%= ENV.fetch("AWS_REGION", "us-east-1") %>
+  bucket: <%= ENV.fetch("AWS_S3_BUCKET", "") %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
Use Images In Content

Reason for Change
=================
From Miro Card: 
> As a content creator I may want to upload images inline to content I'm creating, or link to an externally hosted image. I'd like this process to be easy and not require committing things to Github.

Note that this PR builds on a previous PR [Wireframe website layout](https://github.com/rubycentral/cfp-app/pull/273). While deploying this branch to staging it was revealed that CodeMirror css needed to be imported and included differently with Webpacker in production environment so this PR resolves that as well. 

Changes
=======
- adds ability to upload images from tinymce editor
- allows svg images to be uploaded and to not be treated as binary
- updates preview when image is uploaded or removed with change event
  handler
- turns on amazon storage for production
- fixes CodeMirror css importing for production

[Use images in content](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523893972554&cot=14)