### PR TITLE
sponsor banner ad stimulus controller

### DIFF
--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -39,8 +39,7 @@ body {
 
 #content {
   background-color: var(--main_content_background);
-  padding: 0 20px 0 20px;
-  margin-top: 100px;
+  margin-top: 50px;
 }
 
 p {

--- a/app/assets/stylesheets/themes/default/nav.scss
+++ b/app/assets/stylesheets/themes/default/nav.scss
@@ -9,6 +9,7 @@
   width: 100%;
   background: var(--nav_background_color);
   color: var(--nav_text_color);
+  z-index: 11;
 
   #header-logo-container {
     display: flex;

--- a/app/assets/stylesheets/themes/default/sponsors.scss
+++ b/app/assets/stylesheets/themes/default/sponsors.scss
@@ -164,7 +164,8 @@
 
 .banner-ad-wrapper {
   position: relative;
-  padding-bottom: 15%;
+  height: 170px;
+  padding-bottom: 30px;
   max-height: 170px;
 
   .banner-ad-item {

--- a/app/assets/stylesheets/themes/default/sponsors.scss
+++ b/app/assets/stylesheets/themes/default/sponsors.scss
@@ -162,6 +162,25 @@
   }
 }
 
+.banner-ad-wrapper {
+  position: relative;
+  padding-bottom: 15%;
+  max-height: 170px;
+
+  .banner-ad-item {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    transition: all 200ms ease-in-out;
+
+    img {
+      margin: auto;
+      max-height: 130px;
+    }
+  }
+}
+
 @media screen and (max-width: 1200px) and (orientation: portrait),
   (max-width: 1123px) and (orientation: landscape) {
     .sponsors-wrapper {

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -10,4 +10,9 @@ class SponsorsController < ApplicationController
     @sponsors_in_footer = Sponsor.published.with_footer_image.order_by_tier
     render layout: false
   end
+
+  def banner_ads
+    @sponsors_in_banner = Sponsor.published.with_banner_ad
+    render layout: false
+  end
 end

--- a/app/javascript/controllers/banner_ads_controller.js
+++ b/app/javascript/controllers/banner_ads_controller.js
@@ -4,7 +4,6 @@ export default class extends Controller {
   static targets = [ 'ad' ]
   static values = {
     eventSlug: String,
-    index: Number,
   }
 
   connect() {
@@ -17,15 +16,21 @@ export default class extends Controller {
           .createContextualFragment(html);
         this.element.appendChild(fragment);
 
-        this.showCurrentIndex()
-        this.setAdInterval()
-        this.startAdRotation()
+        this.config()
       })
+  }
+
+  config() {
+    this.setAdInterval()
+    this.setIndex()
+
+    this.showCurrentIndex()
+    this.startAdRotation()
   }
 
   showCurrentIndex() {
     this.adTargets.forEach((ad, index) => {
-      ad.hidden = index != this.indexValue;
+      ad.hidden = index != this.index;
     })
   }
 
@@ -33,16 +38,19 @@ export default class extends Controller {
     this.adInterval = 7500; // 7.5 second ad interval
   }
 
-  startAdRotation() {
-    setInterval(() => {
-      this.indexValue += 1
-      if (this.indexValue >= this.adTargets.length) {
-        this.indexValue = 0
-      }
-    }, this.adInterval)
+  setIndex() {
+    this.index = Math.floor(Math.random() * this.adTargets.length);
   }
 
-  indexValueChanged() {
-    this.showCurrentIndex()
+  startAdRotation() {
+    setInterval(() => {
+
+      this.index += 1
+      if (this.index >= this.adTargets.length) {
+        this.index = 0
+      }
+
+      this.showCurrentIndex()
+    }, this.adInterval)
   }
 }

--- a/app/javascript/controllers/banner_ads_controller.js
+++ b/app/javascript/controllers/banner_ads_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = [ 'ad' ]
+  static values = {
+    eventSlug: String,
+    index: Number,
+  }
+
+  connect() {
+    const path = `/${this.eventSlugValue}/banner_ads`
+    fetch(path)
+      .then((res) => res.text())
+      .then((html) => {
+        const fragment = document
+          .createRange()
+          .createContextualFragment(html);
+        this.element.appendChild(fragment);
+
+        this.showCurrentIndex()
+        this.setAdInterval()
+        this.startAdRotation()
+      })
+  }
+
+  showCurrentIndex() {
+    this.adTargets.forEach((ad, index) => {
+      ad.hidden = index != this.indexValue;
+    })
+  }
+
+  setAdInterval() {
+    this.adInterval = 7500; // 7.5 second ad interval
+  }
+
+  startAdRotation() {
+    setInterval(() => {
+      this.indexValue += 1
+      if (this.indexValue >= this.adTargets.length) {
+        this.indexValue = 0
+      }
+    }, this.adInterval)
+  }
+
+  indexValueChanged() {
+    this.showCurrentIndex()
+  }
+}

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -11,6 +11,7 @@ class Sponsor < ApplicationRecord
 
   scope :published, -> { where(published: true) }
   scope :with_footer_image, -> { joins(:footer_logo_attachment) }
+  scope :with_banner_ad, -> { joins(:banner_ad_attachment) }
   scope :order_by_tier, -> {
     order_case = "CASE tier"
     TIERS.each_with_index do |tier, index|

--- a/app/views/sponsors/banner_ads.html.haml
+++ b/app/views/sponsors/banner_ads.html.haml
@@ -1,0 +1,3 @@
+.banner-ad-wrapper
+  - @sponsors_in_banner.each do |sponsor|
+    = link_to image_tag( sponsor.banner_ad, alt: sponsor.name), sponsor.url, target: "_blank", data: { 'banner-ads-target': 'ad' }

--- a/app/views/sponsors/banner_ads.html.haml
+++ b/app/views/sponsors/banner_ads.html.haml
@@ -1,3 +1,3 @@
 .banner-ad-wrapper
   - @sponsors_in_banner.each do |sponsor|
-    = link_to image_tag( sponsor.banner_ad, alt: sponsor.name), sponsor.url, target: "_blank", data: { 'banner-ads-target': 'ad' }
+    = link_to image_tag( sponsor.banner_ad, alt: sponsor.name), sponsor.url, target: "_blank", class: "banner-ad-item", data: { 'banner-ads-target': 'ad' }

--- a/app/views/sponsors/show.html.haml
+++ b/app/views/sponsors/show.html.haml
@@ -9,3 +9,5 @@
           = tier
         .sponsors-wrapper
           = render sponsors
+
+  %div{ data: { 'controller': 'banner-ads', 'banner-ads-event-slug-value': 'railsconf-2022', 'banner-ads-index-value': '0' } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,7 @@ Rails.application.routes.draw do
   get '/(:slug)/program', to: 'programs#show', as: :program
   get '/(:slug)/schedule', to: 'schedule#show', as: :schedule
   get '/(:slug)/sponsors_footer', to: 'sponsors#sponsors_footer'
+  get '/(:slug)/banner_ads', to: 'sponsors#banner_ads'
   get '/(:slug)/sponsors', to: 'sponsors#show', as: :sponsors
   get '/(:slug)/:page', to: 'pages#show', as: :page
 


### PR DESCRIPTION
🟡  - Still needs a feature spec. 

Reason for Change
=================
The conference websites allowed event sponsors to display banner ads across various website pages. This PR seeks to enable that feature on the event website. 

Website creators/designers will be able to add a specific html stimulus controller to any page body, and that page will display a rotating sponsor banner ad element. 

Changes
=======
- adds a route at the sponsors controller at 'website/banner_ads'
- adds stimulus controller that will query the banner_ad route
- adds a template for the banner_ads route, that will be seeded by the event sponsors with a banner_ad

The element that will enable the sponsors banner would look like
```
<div data-controller="banner-ads" data-banner-ads-event-slug-value="railsconf-2022"></div>
```

Additional Details
=====
- Still needs a test or two.

## Who doesn't love a preview
![Screen Recording 2022-04-28 at 1 24 10 AM](https://user-images.githubusercontent.com/71521423/165700168-42161a91-81ab-45b9-931b-ab507d1ebb61.gif)
