### PR TITLE
Editor Improvements

### DIFF
--- a/app/assets/stylesheets/modules/_staff-website-page.scss
+++ b/app/assets/stylesheets/modules/_staff-website-page.scss
@@ -18,6 +18,7 @@
     resize: both;
     border: 1px solid black;
     height: 70vh;
+    max-width: 70vw;
     .inner {
       flex-grow: 1;
       margin: 0;

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -5,14 +5,4 @@ class SponsorsController < ApplicationController
     @sponsors_by_tier = Sponsor.published.order_by_tier.group_by(&:tier)
     render layout: "themes/#{current_website.theme}"
   end
-
-  def sponsors_footer
-    @sponsors_in_footer = Sponsor.published.with_footer_image.order_by_tier
-    render layout: false
-  end
-
-  def banner_ads
-    @sponsors_in_banner = Sponsor.published.with_banner_ad
-    render layout: false
-  end
 end

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -9,7 +9,7 @@ class Staff::PagesController < Staff::ApplicationController
   end
 
   def show
-    @body = @page.unpublished_body || ""
+    @body = params[:preview] || @page.unpublished_body || ""
     render template: 'pages/show', layout: "themes/#{current_website.theme}"
   end
 

--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -24,4 +24,12 @@ class WebsiteDecorator < ApplicationDecorator
   def closes_at
     event.closes_at(:month_day_year)
   end
+
+  def banner_sponsors
+    event.sponsors.published.with_banner_ad
+  end
+
+  def sponsors_in_footer
+    event.sponsors.published.with_footer_image.order_by_tier
+  end
 end

--- a/app/helpers/page_helper.rb
+++ b/app/helpers/page_helper.rb
@@ -1,0 +1,14 @@
+module PageHelper
+  TAGS = {
+    "<sponsors-banner-adds></sponsors-banner-adds>" => "sponsors/banner_ads",
+    "<sponsors-footer></sponsors-footer>" => "sponsors/sponsors_footer"
+  }
+
+  def embed(body)
+    body.tap do |body|
+      TAGS.each do |tag, template|
+        body.gsub!(tag, render(template: template, layout: false))
+      end
+    end.html_safe
+  end
+end

--- a/app/javascript/controllers/banner_ads_controller.js
+++ b/app/javascript/controllers/banner_ads_controller.js
@@ -7,17 +7,7 @@ export default class extends Controller {
   }
 
   connect() {
-    const path = `/${this.eventSlugValue}/banner_ads`
-    fetch(path)
-      .then((res) => res.text())
-      .then((html) => {
-        const fragment = document
-          .createRange()
-          .createContextualFragment(html);
-        this.element.appendChild(fragment);
-
-        this.config()
-      })
+    this.config()
   }
 
   config() {

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -53,7 +53,6 @@ export default class extends Controller {
     });
     for (var i=0;i<editor.lineCount();i++) { editor.indentLine(i); }
     editor.on('change', (e) => {
-      console.log(this.changedValue);
       this.changedValue = true;
       this.preview(e.getValue());
     })

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -4,9 +4,10 @@ import 'codemirror/mode/htmlmixed/htmlmixed.js'
 
 export default class extends Controller {
   static targets = ['htmlContent', 'wysiwygContent', 'wysiwyg', 'html']
+  static values = { changed: { type: Boolean, default: false } }
 
   initialize () {
-    this.defaults = {
+    this.tinyMCEDefaults = {
       height: 500,
       menubar: false,
       plugins: [
@@ -24,16 +25,14 @@ export default class extends Controller {
       images_file_types: 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp,svg',
       relative_urls: false,
       convert_urls: false,
-      init_instance_callback: function(editor) {
-        var preview = document.getElementById('page-preview');
-        preview.contentWindow.document.getElementById("content").innerHTML = editor.getContent();
-        editor.on('input', function(e) {
-          var preview = document.getElementById('page-preview');
-          preview.contentWindow.document.getElementById("content").innerHTML = e.target.innerHTML;
+      init_instance_callback: (editor) => {
+        editor.on('input', (e) => {
+          this.preview(e.target.innerHTML);
+          this.changedValue = true;
         });
-        editor.on('change', function(e) {
-          var preview = document.getElementById('page-preview');
-          preview.contentWindow.document.getElementById("content").innerHTML = e.target.getContent();
+        editor.on('change', (e) => {
+          this.preview(e.target.getContent());
+          this.changedValue = true;
         });
       }
     }
@@ -44,16 +43,37 @@ export default class extends Controller {
     this.wysiwygTarget.classList.add("hidden");
     this.htmlTarget.classList.remove("hidden");
     this.htmlContentTarget.disabled = false;
+    this.initializeCodeMirror().setValue(this.wysiwygEditor.getContent());
+  }
+
+  initializeCodeMirror() {
     var editor = CodeMirror.fromTextArea(this.htmlContentTarget, {
       mode: "htmlmixed",
       lineWrapping: true,
     });
-    editor.setValue(this.wysiwygEditor.getContent());
     for (var i=0;i<editor.lineCount();i++) { editor.indentLine(i); }
-    editor.on('change', function(e) {
-      var preview = document.getElementById('page-preview');
-      preview.contentWindow.document.getElementById("content").innerHTML = e.getValue();
+    editor.on('change', (e) => {
+      console.log(this.changedValue);
+      this.changedValue = true;
+      this.preview(e.getValue());
     })
+    editor.on('drop', (e, event) => {
+      event.preventDefault();
+      this.uploadFile(event.dataTransfer.files[0], event, e)
+    })
+    return editor;
+  }
+
+  preview(content) {
+    this.debounce(function() {
+      document.getElementById('hidden-preview').value = content;
+      document.getElementById('preview-form').submit();
+    }, 1000)
+  }
+
+  debounce(func, delay) {
+    if(this.timeout) { clearTimeout(this.timeout) }
+    this.timeout = setTimeout(func, delay);
   }
 
   wysiwyg(e) {
@@ -65,6 +85,28 @@ export default class extends Controller {
     this.htmlEditor.toTextArea();
   }
 
+  uploadFile(file, event, editor) {
+    let url = '/image_uploads'
+    let formData = new FormData()
+
+    formData.append('file', file)
+
+    fetch(url, {
+      method: 'POST',
+      body: formData
+    }).then(response => response.json())
+      .then(data => {
+        let newline = `<img src="${data.location}"/>`
+        let doc= editor.getDoc()
+        editor.focus()
+        let x = event.pageX
+        let y = event.pageY
+        editor.setCursor(editor.coordsChar({left:x,top:y}))
+        let newpos = editor.getCursor()
+        doc.replaceRange(newline, newpos)
+      })
+  }
+
   get wysiwygEditor() {
     return tinyMCE.activeEditor;
   }
@@ -73,9 +115,22 @@ export default class extends Controller {
     return document.querySelector('.CodeMirror').CodeMirror;
   }
 
+  leavingPage(event) {
+    console.log(this.changedValue);
+    if (this.changedValue) {
+      event.returnValue = "Are you sure you want to leave with unsaved changes?";
+      return event.returnValue;
+    }
+  }
+
+  allowFormSubmission(event) {
+    this.changedValue = false;
+  }
+
   connect () {
-    let config = Object.assign({ target: this.wysiwygContentTarget }, this.defaults)
+    let config = Object.assign({ target: this.wysiwygContentTarget }, this.tinyMCEDefaults)
     tinyMCE.init(config)
+    this.initializeCodeMirror();
   }
 
   disconnect () {

--- a/app/views/pages/show.html.haml
+++ b/app/views/pages/show.html.haml
@@ -1,1 +1,1 @@
-= @body.html_safe
+= embed(@body)

--- a/app/views/sponsors/banner_ads.html.haml
+++ b/app/views/sponsors/banner_ads.html.haml
@@ -1,3 +1,8 @@
-.banner-ad-wrapper
-  - @sponsors_in_banner.each do |sponsor|
-    = link_to image_tag( sponsor.banner_ad, alt: sponsor.name), sponsor.url, target: "_blank", class: "banner-ad-item", data: { 'banner-ads-target': 'ad' }
+%div{ "data-controller" => "banner-ads" }
+  .banner-ad-wrapper
+    - current_website.banner_sponsors.each do |sponsor|
+      = link_to image_tag(sponsor.banner_ad, alt: sponsor.name),
+        sponsor.url,
+        target: "_blank",
+        class: "banner-ad-item",
+        data: { 'banner-ads-target': 'ad' }

--- a/app/views/sponsors/sponsors_footer.html.haml
+++ b/app/views/sponsors/sponsors_footer.html.haml
@@ -1,4 +1,6 @@
 %h3.section-title
   Sponsors
 .sponsors-footer-wrapper
-  = render partial: "sponsor_footer", collection: @sponsors_in_footer, as: :sponsor
+  = render partial: "sponsors/sponsor_footer",
+    collection: current_website.sponsors_in_footer,
+    as: :sponsor

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -32,7 +32,6 @@
         data: { action: "editor#allowFormSubmission" })
       = link_to "Cancel", event_staff_pages_path(current_event), {:class=>"cancel-form btn btn-danger"}
 = form_with url: event_staff_page_path(current_event, @page),
-  method: :get,
   html: { target: "page-preview", id: "preview-form" } do |f|
   = f.hidden_field :preview, id: "hidden-preview"
 

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -1,28 +1,38 @@
-= simple_form_for [current_event, :staff, page] do |f|
-  .preview-flex{ data: { controller: :editor } }
+= simple_form_for([current_event, :staff, page],
+  { data: { controller: :editor,
+  action: "beforeunload@window->editor#leavingPage",
+  'editor-changed-value' => "false" } }) do |f|
+  .preview-flex
     .resize
       .inner
         = f.input :name
         = f.input :slug
         = f.input :hide_header, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         = f.input :hide_footer, as: :boolean, wrapper: :vertical_radio_and_checkboxes
-        %div{ data: { controller: :editor } }
-          %div{ data: { "editor-target": :wysiwyg } }
-            = f.input :unpublished_body,
-              as: :text,
-              input_html: { data: { "editor-target": :wysiwygContent } }
-            = link_to("Edit HTML", '#', { data: { action: "click->editor#editHtml" } })
-          %div{ data: { "editor-target": :html }, class: 'hidden' }
-            = f.input :unpublished_body,
-              as: :text,
-              input_html: { data: { "editor-target": :htmlContent }, disabled: true }
-            = link_to("WYSIWYG", '#', { data: { action: "click->editor#wysiwyg" } })
+        %div{ data: { "editor-target": :wysiwyg }, class: 'hidden', disabled: true }
+          = f.input :unpublished_body,
+            as: :text,
+            input_html: { data: { "editor-target": :wysiwygContent } }
+          = link_to("Edit HTML", '#', { data: { action: "click->editor#editHtml" } })
+        %div{ data: { "editor-target": :html } }
+          = f.input :unpublished_body,
+            as: :text,
+            input_html: { data: { "editor-target": :htmlContent } }
+          = link_to("WYSIWYG", '#', { data: { action: "click->editor#wysiwyg" } })
     .resize
       #page-preview-wrapper
         %h4 Preview Page
         %iframe{ src: "#{event_staff_page_path(current_event, @page, params.to_unsafe_hash)}",
-                 id: "page-preview" }
+                 id: "page-preview", name: "page-preview" }
   .row
     .col-sm-12
-      = submit_tag("Save", class: "btn btn-success", type: "submit")
+      = submit_tag("Save",
+        class: "btn btn-success",
+        type: "submit",
+        data: { action: "editor#allowFormSubmission" })
       = link_to "Cancel", event_staff_pages_path(current_event), {:class=>"cancel-form btn btn-danger"}
+= form_with url: event_staff_page_path(current_event, @page),
+  method: :get,
+  html: { target: "page-preview", id: "preview-form" } do |f|
+  = f.hidden_field :preview, id: "hidden-preview"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
       resources :pages do
         member do
           get :preview
+          post :show
           patch :publish
           patch :promote
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,8 +165,6 @@ Rails.application.routes.draw do
   get '/(:slug)', to: 'pages#show', as: :landing
   get '/(:slug)/program', to: 'programs#show', as: :program
   get '/(:slug)/schedule', to: 'schedule#show', as: :schedule
-  get '/(:slug)/sponsors_footer', to: 'sponsors#sponsors_footer'
-  get '/(:slug)/banner_ads', to: 'sponsors#banner_ads'
   get '/(:slug)/sponsors', to: 'sponsors#show', as: :sponsors
   get '/(:slug)/:page', to: 'pages#show', as: :page
 

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :sponsor do
-    event
+    event { Event.first || create(:event) }
     name { Faker::Company.name }
     published { true }
     tier { 'platinum' }

--- a/spec/features/website/sponsor_spec.rb
+++ b/spec/features/website/sponsor_spec.rb
@@ -26,7 +26,7 @@ feature 'Wesite displays an events sponsors' do
     end
 
     it 'Website pages can display a sponsors footer', js: true do
-      sponsor_footer_logo = create(:sponsor, :with_footer_logo)
+      create(:sponsor, :with_footer_logo)
       home_page = create(:page, published_body: "Home")
 
       visit sponsors_path(event)
@@ -35,8 +35,7 @@ feature 'Wesite displays an events sponsors' do
       visit page_path(event, page: home_page.slug)
       expect(page).to_not have_css("img[src*='ruby1.png']")
 
-      sponsors_footer_element = "<div data-controller='sponsors-footer'
-                                      data-sponsors-footer-event-slug-value='#{event.slug}'>"
+      sponsors_footer_element = "<sponsors-footer></sponsors-footer>"
 
       home_page.update(published_body: sponsors_footer_element)
       visit page_path(event, page: home_page.slug)
@@ -46,8 +45,7 @@ feature 'Wesite displays an events sponsors' do
 
     it "Sponsors footer displays a sponsor offer on click if sponsor has offer available", js: true do
       sponsor = create(:sponsor, :with_footer_logo, :with_offer)
-      sponsors_footer_element = "<div data-controller='sponsors-footer'
-                                      data-sponsors-footer-event-slug-value='#{event.slug}'>"
+      sponsors_footer_element = "<sponsors-footer></sponsors-footer>"
       home_page = create(:page, published_body: sponsors_footer_element)
 
       visit page_path(event, page: home_page.slug)


### PR DESCRIPTION
Reason for Change
=================

While thinking about page caching I was feeling concerned about the complexity of having the sponsor banner adds and footer components being loading asynchronously. It suddenly occurred to me that we could easily be rendering those server side with a simple `gsub` of custom tags. This also had the added benefit of making the tags much simpler for a content editor to add to the page. Unfortunately though it led me down some rabbit holes but hopefully led to some improvements.

First of all previewing of pages with banners or footers while editing broke because we were just swapping out the html in the iframe. I found an interesting solution of instead making a request from a hidden form with the iframe as the target (I did not know you could do this but seemed pretty cool and it just worked). However, that meant a lot of page requests with every edit change so I added a debounce to the requests. The experience is not as smooth as it was but hopefully it is acceptable. I also considered adding the autosave feature and reloading the iframe with the saved content but that had other problems including how to deal with a new page that is not yet persisted. 

I originally hoped that the tags could be simple self-closing tags like `<sponsors-footer/>` but unfortunately tinyMCE has another nasty habit of changing those to `<sponsors-footer></sponsors-footer>`. The easiest fix was to just accept it and require the tags to be a matching pair. However, it did make me want to explore what it would take to get rid of tinyMCE. 
In that vein I added image uploading to CodeMirror by allowing a file to be dropped into the html. I am not sure that we want to totally get rid of tinyMCE but I at least made it the default that is rendered when you first start editing. 

Since autosaving seemed complicated I decided to start with a beforeunload event handler managed in the editor stimulus controller. Another small improvement was adding a max-width on the resizable form and preview windows. I also along the way added a missing scope on the sponsors to the current_website which we would have eventually caught. 

Changes
=======
- renders sponsors banner and footer server-side by replacing embedded
  custom tags
- changes preview process in editor by refreshing iframe with the
  unpublished body so that tags get embedded
- adds ability to drop images into CodeMirror
- makes CodeMirror the initial default editor instead of tinyMCE
- adds beforeunload warning when there are unsaved editor changes
- adds max-width on resize editor form and preview windows
- scopes sponsors in banner and footer to current website

[Page and image caching in edge network](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523894399331&cot=14)