### PR TITLE
Adds ability to remove page from navigation and/or hide it entirely

### DIFF
--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -91,6 +91,8 @@ class Staff::PagesController < Staff::ApplicationController
         :template,
         :name,
         :slug,
+        :hide_navigation,
+        :hide_page,
         :hide_header,
         :hide_footer,
         :unpublished_body

--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -32,4 +32,8 @@ class WebsiteDecorator < ApplicationDecorator
   def sponsors_in_footer
     event.sponsors.published.with_footer_image.order_by_tier
   end
+
+  def navigation_page_names_and_slugs
+    pages.navigatable.pluck(:name, :slug)
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,7 +5,8 @@ class Page < ApplicationRecord
 
   belongs_to :website
 
-  scope :published, -> { where.not(published_body: nil) }
+  scope :published, -> { where.not(published_body: nil).where(hide_page: false) }
+  scope :navigatable, -> { published.where.not(hide_navigation: true) }
 
   validates :name, :slug, presence: true
   validates :slug, uniqueness: { scope: :website_id }

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -16,8 +16,8 @@
           %h1
             = link_to(current_website.name, landing_path(website_event_slug))
         %nav#main-nav
-          - current_website.pages.published.each do |page|
-            = link_to page.name, page_path(website_event_slug, page)
+          - current_website.navigation_page_names_and_slugs.each do |page_name, page_slug|
+            = link_to page_name, page_path(website_event_slug, page_slug)
           = link_to "Schedule", schedule_path(current_website.event)
           = link_to "Program", program_path(website_event_slug)
           = link_to "Sponsors", sponsors_path(website_event_slug)
@@ -37,7 +37,6 @@
         .footer-event-links
           - current_website.pages.published.each do |page|
             = link_to page.name, page_path(website_event_slug, page)
-          = link_to "Schedule", schedule_path(current_website.event)
           = link_to "Schedule", schedule_path(current_website.event)
           = link_to "Program", program_path(website_event_slug)
           = link_to "Sponsors", sponsors_path(website_event_slug)

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -7,6 +7,8 @@
       .inner
         = f.input :name
         = f.input :slug
+        = f.input :hide_navigation, as: :boolean, wrapper: :vertical_radio_and_checkboxes
+        = f.input :hide_page, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         = f.input :hide_header, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         = f.input :hide_footer, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         %div{ data: { "editor-target": :wysiwyg }, class: 'hidden', disabled: true }

--- a/db/migrate/20220503085207_add_hiding_fields_to_pages.rb
+++ b/db/migrate/20220503085207_add_hiding_fields_to_pages.rb
@@ -1,0 +1,6 @@
+class AddHidingFieldsToPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pages, :hide_page, :boolean, default: false, null: false
+    add_column :pages, :hide_navigation, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_28_160329) do
+ActiveRecord::Schema.define(version: 2022_05_03_085207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,8 @@ ActiveRecord::Schema.define(version: 2022_04_28_160329) do
     t.boolean "landing", default: false, null: false
     t.boolean "hide_header", default: false, null: false
     t.boolean "hide_footer", default: false, null: false
+    t.boolean "hide_page", default: false, null: false
+    t.boolean "hide_navigation", default: false, null: false
     t.index ["website_id"], name: "index_pages_on_website_id"
   end
 

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -96,4 +96,26 @@ feature "Website Page Management" do
     expect(page).not_to have_css('footer')
   end
 
+  scenario "Organizer hides navigation to a page and hides a page entirely", :js do
+    home_page = create(:page, published_body: 'Home Content')
+    visit page_path(slug: event.slug, page: home_page.slug)
+    expect(page).to have_content('Home Content')
+    within('#main-nav') { expect(page).to have_content(home_page.name) }
+
+    login_as(organizer)
+    visit edit_event_staff_page_path(event, home_page)
+    check("Hide navigation")
+    click_on("Save")
+
+    visit page_path(slug: event.slug, page: home_page.slug)
+    within('#main-nav') { expect(page).not_to have_content(home_page.name) }
+
+    visit edit_event_staff_page_path(event, home_page)
+    check("Hide page")
+    click_on("Save")
+
+    visit page_path(slug: event.slug, page: home_page.slug)
+    expect(page).to have_content("Page Not Found")
+  end
+
 end


### PR DESCRIPTION
Reason for Change
=================
This PR adds two different boolean fields on Page to help control its visibility in the website. `Page#hide_navigation` will just remove a page from the navigation. This will allow a page like a Splash page or some less significant content page to be published but not take up space in the navigation. On the other hand there is also now a `Page#hide_page` flag that will essentially unpublish a page such that it cannot be visible to the public. 

Changes
=======
- adds Page#hide_navigation and #hide_page boolean
- adds hide_page: false condition to published scope
- adds WebsiteDecorator#navigation_page_names_and_slugs for more
  efficient generation of navigation links with just names and slugs


[Unpublish a page/hide link](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764524471808252&cot=14)
