### PR TITLE
Control the order of navigation links

### DIFF
--- a/app/assets/javascripts/base.js
+++ b/app/assets/javascripts/base.js
@@ -6,8 +6,12 @@ $(document).ready(function() {
     $(".alert").not('.alert-confirm, .scheduling-error').alert('close');
   }, 5000);
 
-  $(".selectize-tags").selectize({
-    delimiter: ",",
+  $(".selectize-sortable").selectize({
+    plugins: ["drag_drop"],
+  });
+
+  $(".selectize-create").selectize({
+    plugins: ["drag_drop"],
     persist: false,
     create: function (input) {
       return {

--- a/app/assets/stylesheets/modules/_code-mirror.scss
+++ b/app/assets/stylesheets/modules/_code-mirror.scss
@@ -1,5 +1,6 @@
 .CodeMirror {
   /* Bootstrap Settings */
+  min-height: 60vh;
   box-sizing: border-box;
   margin: 0;
   font: inherit;

--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -10,7 +10,7 @@
   --body_background_color: white;
   --nav_background_color: black;
   --nav_text_color: white;
-  --nav_link_hover: black;
+  --nav_link_hover: white;
   --main_content_background: white;
   --sans-serif-font: 'Rubik';
 }

--- a/app/assets/stylesheets/themes/default/footer.scss
+++ b/app/assets/stylesheets/themes/default/footer.scss
@@ -1,8 +1,8 @@
 footer {
   color: white;
   .overlay {
-    background-color: black !important;
-    opacity: 0.9 !important;
+    background-color: black;
+    opacity: 0.9;
     padding: 20px 30px 35px;
   }
   .footer-header {

--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -91,7 +91,6 @@ class Staff::PagesController < Staff::ApplicationController
         :template,
         :name,
         :slug,
-        :hide_navigation,
         :hide_page,
         :hide_header,
         :hide_footer,

--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -24,7 +24,7 @@ class Staff::WebsitesController < Staff::ApplicationController
   private
 
   def set_website
-    @website = current_event.website || current_event.build_website
+    @website = (current_event.website || current_event.build_website).decorate
   end
 
   def authorize_website
@@ -47,7 +47,8 @@ class Staff::WebsitesController < Staff::ApplicationController
         :twitter_handle,
         :facebook_url,
         :instagram_url,
-        :footer_categories,
+        footer_categories: [],
+        navigation_links: [],
       )
   end
 end

--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -1,6 +1,12 @@
 class WebsiteDecorator < ApplicationDecorator
   delegate_all
 
+  DEFAULT_LINKS = {
+    'Schedule' => 'schedule',
+    'Program' => 'program',
+    'Sponsors' => 'sponsors',
+  }.freeze
+
   def name
     event.name
   end
@@ -13,7 +19,7 @@ class WebsiteDecorator < ApplicationDecorator
     @event ||= object.event.decorate
   end
 
-  def location
+  def formatted_location
     h.simple_format(object.location)
   end
 
@@ -33,15 +39,11 @@ class WebsiteDecorator < ApplicationDecorator
     event.sponsors.published.with_footer_image.order_by_tier
   end
 
-  def navigation_page_names_and_slugs
-    pages.navigatable.pluck(:name, :slug)
-  end
-
   def categorized_footer_pages
     pages.in_footer
       .select(:footer_category, :name, :slug)
       .group_by(&:footer_category)
-      .sort_by { |category, _| footer_categories.index(category) }
+      .sort_by { |category, _| footer_categories.index(category) || 1_000 }
   end
 
   def twitter_url
@@ -56,5 +58,12 @@ class WebsiteDecorator < ApplicationDecorator
     return {} unless background.attached?
 
     { style: "background-image: url('#{h.url_for(background)}');" }
+  end
+
+  def link_options
+    @link_options ||= pages.published.pluck(:name, :slug)
+      .each_with_object(DEFAULT_LINKS.dup) do |(name, slug), memo|
+      memo[name] = slug
+    end
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -7,7 +7,6 @@ class Page < ApplicationRecord
   belongs_to :website
 
   scope :published, -> { where.not(published_body: nil).where(hide_page: false) }
-  scope :navigatable, -> { published.where(hide_navigation: false) }
   scope :in_footer, -> { published.where.not(footer_category: [nil, ""]) }
 
   validates :name, :slug, presence: true
@@ -15,6 +14,10 @@ class Page < ApplicationRecord
   attr_accessor :template
 
   BLANK_SLUG = "0"
+
+  def published?
+    published_body.present? && !hide_page
+  end
 
   def to_param
     persisted? ? slug : BLANK_SLUG
@@ -48,7 +51,7 @@ end
 #  hide_header      :boolean          default(FALSE), not null
 #  hide_footer      :boolean          default(FALSE), not null
 #  hide_page        :boolean          default(FALSE), not null
-#  hide_navigation  :boolean          default(FALSE), not null
+#  footer_category  :string
 #
 # Indexes
 #

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -7,11 +7,6 @@ class Website < ApplicationRecord
 
   DEFAULT = 'default'.freeze
 
-  def footer_categories=(values)
-    categories = values.is_a?(String) ? values.split(',') : values
-    self[:footer_categories] = categories
-  end
-
   def self.domain_match(domain)
     where(arel_table[:domains].matches("%#{(domain)}"))
   end
@@ -21,18 +16,23 @@ end
 #
 # Table name: websites
 #
-#  id                :bigint(8)        not null, primary key
-#  event_id          :bigint(8)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  theme             :string           default("default")
-#  domains           :string
-#  city              :string
-#  location          :text
-#  prospectus_link   :string
-#  twitter_handle    :string
-#  directions        :string
-#  footer_categories :string           is an Array
+#  id                   :bigint(8)        not null, primary key
+#  event_id             :bigint(8)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  theme                :string           default("default")
+#  domains              :string
+#  city                 :string
+#  location             :text
+#  prospectus_link      :string
+#  twitter_handle       :string
+#  directions           :string
+#  footer_categories    :string           default([]), is an Array
+#  footer_about_content :text
+#  footer_copyright     :string
+#  facebook_url         :string
+#  instagram_url        :string
+#  navigation_links     :string           default([]), is an Array
 #
 # Indexes
 #

--- a/app/views/layouts/themes/default/_footer.html.haml
+++ b/app/views/layouts/themes/default/_footer.html.haml
@@ -12,7 +12,7 @@
         .location-section
           .location-details
             .date #{current_website.date_range}
-            .location #{simple_format(current_website.location)}
+            .location #{current_website.formatted_location}
           .register
             - if current_website.register_page
               = link_to 'Register',

--- a/app/views/layouts/themes/default/_header.html.haml
+++ b/app/views/layouts/themes/default/_header.html.haml
@@ -8,8 +8,5 @@
         .city
           = current_website.city
     %nav#main-nav
-      - current_website.navigation_page_names_and_slugs.each do |page_name, page_slug|
-        = link_to page_name, page_path(website_event_slug, page_slug)
-      = link_to "Schedule", schedule_path(current_website.event)
-      = link_to "Program", program_path(website_event_slug)
-      = link_to "Sponsors", sponsors_path(website_event_slug)
+      - current_website.navigation_links.each do |slug|
+        = link_to current_website.link_options.key(slug), page_path(website_event_slug, slug)

--- a/app/views/staff/pages/_form.html.haml
+++ b/app/views/staff/pages/_form.html.haml
@@ -7,7 +7,6 @@
       .inner
         = f.input :name
         = f.input :slug
-        = f.input :hide_navigation, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         = f.input :hide_page, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         = f.input :hide_header, as: :boolean, wrapper: :vertical_radio_and_checkboxes
         = f.input :hide_footer, as: :boolean, wrapper: :vertical_radio_and_checkboxes

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -2,6 +2,9 @@
   %td= link_to(page.name, edit_event_staff_page_path(current_event, page))
   %td= link_to(page.slug, edit_event_staff_page_path(current_event, page))
   %td
+    - if page.published?
+      %span.glyphicon.glyphicon-ok
+  %td
     - if page.landing?
       %span.glyphicon.glyphicon-ok
   %td

--- a/app/views/staff/pages/index.html.haml
+++ b/app/views/staff/pages/index.html.haml
@@ -13,6 +13,7 @@
         %tr
           %th Name
           %th Slug
+          %th Published
           %th Landing Page
           %th Actions
       %tbody

--- a/app/views/staff/pages/themes/default/splash.html.erb
+++ b/app/views/staff/pages/themes/default/splash.html.erb
@@ -32,7 +32,7 @@
       <div class="text-xl font-semibold"><%= current_website.city %></div>
       <div class="text-2xl font-semibold mt-4 mb-2"><%= current_website.date_range %></div>
       <div class="text-left">
-        <%= current_website.location %>
+        <%= current_website.formatted_location %>
         <%= link_to("directions", current_website.directions, class: "mt-2 underline") %>
       </div>
     </div>

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -17,10 +17,16 @@
       = f.input :directions
       = f.input :prospectus_link
       %fieldset
+        = f.label :navigation_links
+        = f.select :navigation_links,
+          website.link_options,
+          { include_hidden: false },
+          { class: 'selectize-sortable', multiple: true }
         = f.label :footer_categories
-        = f.text_field :footer_categories,
-          value: website.footer_categories&.join(','),
-          class: 'selectize-tags'
+        = f.select :footer_categories,
+          website.footer_categories,
+          { include_hidden: false },
+          { class: 'selectize-create', multiple: true }
         = f.input :footer_about_content
         = f.input :footer_copyright
         = f.input :twitter_handle

--- a/db/migrate/20220504213512_add_navigation_links_to_websites.rb
+++ b/db/migrate/20220504213512_add_navigation_links_to_websites.rb
@@ -1,0 +1,7 @@
+class AddNavigationLinksToWebsites < ActiveRecord::Migration[6.1]
+  def change
+    add_column :websites, :navigation_links, :string, array: true, default: []
+    change_column :websites, :footer_categories, :string, array: true, default: []
+    remove_column :pages, :hide_navigation, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_04_045808) do
+ActiveRecord::Schema.define(version: 2022_05_04_213512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,7 +114,6 @@ ActiveRecord::Schema.define(version: 2022_05_04_045808) do
     t.boolean "hide_header", default: false, null: false
     t.boolean "hide_footer", default: false, null: false
     t.boolean "hide_page", default: false, null: false
-    t.boolean "hide_navigation", default: false, null: false
     t.string "footer_category"
     t.index ["website_id"], name: "index_pages_on_website_id"
   end
@@ -337,11 +336,12 @@ ActiveRecord::Schema.define(version: 2022_05_04_045808) do
     t.string "prospectus_link"
     t.string "twitter_handle"
     t.string "directions"
-    t.string "footer_categories", array: true
+    t.string "footer_categories", default: [], array: true
     t.text "footer_about_content"
     t.string "footer_copyright"
     t.string "facebook_url"
     t.string "instagram_url"
+    t.string "navigation_links", default: [], array: true
     t.index ["event_id"], name: "index_websites_on_event_id"
   end
 

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -16,7 +16,7 @@ feature "Website Configuration" do
     expect(event.website).to be_present
   end
 
-  scenario "Organizer configures domain for an existing website for event" do
+  scenario "Organizer configures domain for an existing website for event", :js do
     website = create(:website, event: event)
     home_page = create(:page, website: website)
 
@@ -31,6 +31,7 @@ feature "Website Configuration" do
     expect(page).to have_content("Edit Website")
 
     fill_in('Domains', with: 'www.example.com')
+    fill_in('Navigation links', with: "Home\n")
     click_on("Save")
 
     expect(page).to have_content("Website was successfully updated")

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -56,13 +56,10 @@ feature "Website Page Management" do
 
     expect(page).to have_content('Home Page was successfully published.')
 
-    visit page_path(slug: event.slug, page: home_page.slug)
-    expect(page).to have_content('Home Content')
-    within('#main-nav') { expect(page).to have_content(home_page.name) }
-  end
+    click_on('Configuration')
+    fill_in('Navigation links', with: "Home\n")
+    click_on('Save')
 
-  scenario "Public views a published website page" do
-    home_page = create(:page, published_body: 'Home Content')
     visit page_path(slug: event.slug, page: home_page.slug)
     expect(page).to have_content('Home Content')
     within('#main-nav') { expect(page).to have_content(home_page.name) }
@@ -98,13 +95,15 @@ feature "Website Page Management" do
 
   scenario "Organizer hides navigation to a page and hides a page entirely", :js do
     home_page = create(:page, published_body: 'Home Content')
+    website.update(navigation_links: [home_page.slug])
     visit page_path(slug: event.slug, page: home_page.slug)
     expect(page).to have_content('Home Content')
-    within('#main-nav') { expect(page).to have_content(home_page.name) }
+    within('#main-nav') { expect(page).to have_link(home_page.name) }
 
     login_as(organizer)
-    visit edit_event_staff_page_path(event, home_page)
-    check("Hide navigation")
+    visit edit_event_staff_website_path(event)
+    find_field('Navigation links').send_keys(:backspace)
+    fill_in('Navigation links', with: "Schedule\n")
     click_on("Save")
 
     visit page_path(slug: event.slug, page: home_page.slug)
@@ -148,8 +147,5 @@ feature "Website Page Management" do
       expect(page).to have_content('Sponsor')
       expect(page).to have_content('FAQs')
     end
-
-
-
   end
 end

--- a/spec/features/website/page_viewing_spec.rb
+++ b/spec/features/website/page_viewing_spec.rb
@@ -6,6 +6,7 @@ feature 'Public Page Viewing' do
 
   scenario 'Public views a published website page' do
     home_page = create(:page, published_body: 'Home Content')
+    website.update(navigation_links: [home_page.slug])
     visit page_path(slug: event.slug, page: home_page.slug)
 
     expect(page).to have_content('Home Content')
@@ -30,6 +31,7 @@ feature 'Public Page Viewing' do
   scenario 'Public views the landing page for an older website on custom domain' do
     website.update(domains: 'www.example.com')
     old_home_page = create(:page, published_body: 'Old Website', landing: true)
+    website.update(navigation_links: [old_home_page.slug])
 
     new_website = create(:website, domains: 'www.example.com')
     new_home_page = create(:page,
@@ -37,6 +39,7 @@ feature 'Public Page Viewing' do
                            published_body: 'New Website',
                            landing: true)
 
+    new_website.update(navigation_links: [new_home_page.slug])
     visit root_path
     expect(page).to have_content('New Website')
 


### PR DESCRIPTION
Control the order of navigation links

Reason for Change
=================
From Miro Story: 
>As a designer, I need to be able to determine the ordering of navigation links, so that I can control the layout of navigation on the site. This lets me put important links first.

This PR cleverly uses selectize along with the included drag-and-drop plugin to select and order both the static and dynamic pages to control the visibility and order of the navigation links. Hopefully this simplifies the navigation management. 
While working on the navigation links I recognized that using a select gets selectize to submit the values as an array which I was able to similarly use to cleanup `Website#footer_categories`. 

Changes
=======
- adds ability to select and sort order of static and dynamic pages to
  appear in the navigation using selectize
- removes Page#hide_navigation for controlling page nav visibility
- simplifies Website#footer_categories by using selectize with select to
  create an array instead of string
- adds published boolean view to pages#index view
- fixes hover color for header nav links

[Control the order of navigation links](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523892494933&cot=14)
