### PR TITLE
Change the typography of the site

### DIFF
--- a/app/assets/stylesheets/modules/_forms.scss
+++ b/app/assets/stylesheets/modules/_forms.scss
@@ -58,3 +58,9 @@ span[title="required"] {
 input.boolean {
   margin: 4px;
 }
+
+.inline-form {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}

--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -13,6 +13,7 @@
   --nav_link_hover: white;
   --main_content_background: white;
   --sans-serif-font: 'Rubik';
+  --secondary-body-font: 'Rubik'
 }
 
 html {
@@ -43,6 +44,7 @@ header + #content {
 }
 
 p {
+  font-family: var(--secondary-body-font);
   font-size: 14px;
   line-height: 21px;
   margin-bottom: 20px;

--- a/app/assets/stylesheets/themes/default/program.scss
+++ b/app/assets/stylesheets/themes/default/program.scss
@@ -115,6 +115,7 @@
   }
 
   .session-abstract {
+    font-family: var(--secondary-body-font);
     height: 6.25rem;
     font-size: 16px;
     font-weight: 400;
@@ -130,6 +131,7 @@
   }
 
   .session-format-tag {
+    font-family: var(--secondary-body-font);
     padding: 8px 10px 8px 50px;
     border: 1px solid $divider-light;
     border-radius: 100px;
@@ -155,6 +157,7 @@
   }
 
   .track-tag {
+    font-family: var(--secondary-body-font);
     font-size: 12px;
     padding: 7px 10px;
     border-radius: 20px;

--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -51,6 +51,10 @@ class Staff::WebsitesController < Staff::ApplicationController
         navigation_links: [],
         session_format_configs_attributes: [
           :id, :name, :display, :position, :session_format_id
-        ])
+        ],
+        fonts_attributes: [
+          :id, :name, :file, :_destroy, :primary, :secondary
+        ],
+    )
   end
 end

--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -107,4 +107,25 @@ class WebsiteDecorator < ApplicationDecorator
   def session_format_name(session_format)
     object.session_format_configs.find_by(session_format: session_format).name
   end
+
+  def font_faces_css
+    fonts.map do |font|
+      <<~CSS
+        @font-face {
+          font-family: "#{font.name}";
+          src: url('#{h.url_for(font.file)}');
+        }
+      CSS
+    end.join("\n").html_safe
+  end
+
+  def font_root_css
+    font = fonts.primary.first
+    return "" unless font
+    <<~CSS.html_safe
+      :root {
+        --sans-serif-font: '#{font.name}' !important;
+      }
+    CSS
+  end
 end

--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -120,11 +120,14 @@ class WebsiteDecorator < ApplicationDecorator
   end
 
   def font_root_css
-    font = fonts.primary.first
-    return "" unless font
+    font_primary = fonts.primary.first
+    font_secondary = fonts.secondary.first
+
+    return "" unless font_primary || font_secondary
     <<~CSS.html_safe
       :root {
-        --sans-serif-font: '#{font.name}' !important;
+        #{"--sans-serif-font: '#{font_primary.name}' !important;" if font_primary}
+        #{"--secondary-body-font: '#{font_secondary.name}' !important;" if font_secondary}
       }
     CSS
   end

--- a/app/helpers/website_helper.rb
+++ b/app/helpers/website_helper.rb
@@ -2,4 +2,10 @@ module WebsiteHelper
   def website_event_slug
     params[:slug] || (@older_domain_website && @older_domain_website.event.slug)
   end
+
+  def font_file_label(font)
+    "File".tap do |label|
+      label.concat(" (Current File: #{font.file.filename.to_s})") if font.file.attached?
+    end
+  end
 end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -115,7 +115,6 @@ export default class extends Controller {
   }
 
   leavingPage(event) {
-    console.log(this.changedValue);
     if (this.changedValue) {
       event.returnValue = "Are you sure you want to leave with unsaved changes?";
       return event.returnValue;

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "links", "template", "grouped" ]
+
+  connect() {
+    this.wrapperClass = this.data.get("wrapperClass") || "nested-fields"
+  }
+
+  add_association(event) {
+    event.preventDefault()
+
+    var content = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, new Date().getTime())
+    this.linksTarget.insertAdjacentHTML('beforebegin', content)
+  }
+
+  remove_association(event) {
+    event.preventDefault()
+
+    let wrapper = event.target.closest("." + this.wrapperClass)
+
+    // New records are simply removed from the page
+    if (wrapper.dataset.newRecord == "true") {
+      wrapper.remove()
+
+    // Existing records are hidden and flagged for deletion
+    } else {
+      wrapper.querySelector("input[name*='_destroy']").value = 1
+      wrapper.style.display = 'none'
+    }
+  }
+
+  radio_chosen(event) {
+    var els = this.element.getElementsByClassName(event.target.classList[0])
+    Array.from(els).forEach( (e) => {
+      e.checked = false;
+    });
+    event.target.checked = true;
+  }
+}

--- a/app/models/session_format_config.rb
+++ b/app/models/session_format_config.rb
@@ -9,3 +9,27 @@ class SessionFormatConfig < ApplicationRecord
     session_format.name.parameterize.pluralize
   end
 end
+
+# == Schema Information
+#
+# Table name: session_format_configs
+#
+#  id                :bigint(8)        not null, primary key
+#  website_id        :bigint(8)
+#  session_format_id :bigint(8)
+#  position          :integer
+#  name              :string
+#  display           :boolean
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_session_format_configs_on_session_format_id  (session_format_id)
+#  index_session_format_configs_on_website_id         (website_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (session_format_id => session_formats.id)
+#  fk_rails_...  (website_id => websites.id)
+#

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,9 +1,12 @@
 class Website < ApplicationRecord
   belongs_to :event
   has_many :pages, dependent: :destroy
+  has_many :fonts, class_name: 'Website::Font', dependent: :destroy
 
   has_many :session_formats, through: :event
   has_many :session_format_configs
+
+  accepts_nested_attributes_for :fonts, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :session_format_configs
 
   has_one_attached :logo

--- a/app/models/website/font.rb
+++ b/app/models/website/font.rb
@@ -4,6 +4,7 @@ class Website::Font < ApplicationRecord
   has_one_attached :file
 
   scope :primary, -> { where(primary: true) }
+  scope :secondary, -> { where(secondary: true) }
 end
 
 # == Schema Information

--- a/app/models/website/font.rb
+++ b/app/models/website/font.rb
@@ -1,0 +1,24 @@
+class Website::Font < ApplicationRecord
+  belongs_to :website
+
+  has_one_attached :file
+
+  scope :primary, -> { where(primary: true) }
+end
+
+# == Schema Information
+#
+# Table name: website_fonts
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :string
+#  primary    :boolean
+#  secondary  :boolean
+#  website_id :bigint(8)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_website_fonts_on_website_id  (website_id)
+#

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -5,7 +5,9 @@
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     = stylesheet_link_tag current_website.theme, media: 'all'
     = javascript_pack_tag "application"
-    %link{rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Rubik:wght@400;700"}
+    :css
+      #{current_website.font_faces_css}
+      #{current_website.font_root_css}
     %script{src: "https://cdn.tailwindcss.com" }
   %body
     - unless @page&.hide_header?

--- a/app/views/schedule/show.html.haml
+++ b/app/views/schedule/show.html.haml
@@ -4,13 +4,13 @@
     %ul
       %li
         %a#schedule-day-link.selected{ href: "#", 'data-displayedId': 'schedule-day-one', data: { action: 'click->sub-nav#updateDisplay' } }
-          = current_event.conference_date(1).strftime("%B %e")
+          = current_event.conference_date(1).strftime("%B %-e")
       %li
         %a#schedule-day-link{ href: "#", 'data-displayedId': 'schedule-day-two', data: { action: 'click->sub-nav#updateDisplay' } }
-          = current_event.conference_date(2).strftime("%B %e")
+          = current_event.conference_date(2).strftime("%B %-e")
       %li
         %a#schedule-day-link{ href: "#", 'data-displayedId': 'schedule-day-three', data: { action: 'click->sub-nav#updateDisplay' } }
-          = current_event.conference_date(3).strftime("%B %e")
+          = current_event.conference_date(3).strftime("%B %-e")
 
   #schedule-container
     #schedule-day-one{ data: { 'sub-nav-target': 'hideable' }}

--- a/app/views/staff/websites/_font_fields.html.haml
+++ b/app/views/staff/websites/_font_fields.html.haml
@@ -1,0 +1,19 @@
+= content_tag :div,
+  class: 'inline-form nested-fields',
+  data: { new_record: form.object.new_record? } do
+  = form.input :name
+  = form.input :file, label: font_file_label(form.object)
+  .form-group
+    = form.label 'Primary'
+    %div
+      = form.check_box :primary,
+        class: 'primary-font',
+        data: { action: "click->nested-form#radio_chosen" }
+  .form-group
+    = form.label 'Secondary'
+    %div
+      = form.check_box :secondary,
+        class: 'secondary-font',
+        data: { action: "click->nested-form#radio_chosen" }
+  = link_to "Remove", "#", data: { action: "click->nested-form#remove_association" }
+  = form.hidden_field :_destroy

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -39,10 +39,24 @@
       = f.simple_fields_for :session_format_configs do |ff|
         .session-format-name
           = "Configure #{ff.object.session_format.name}"
-        = ff.input :display, wrapper_html: { class: 'col-md-3' }
-        = ff.input :position, wrapper_html: { class: 'col-md-3' }
-        = ff.input :name
-        = ff.hidden_field :session_format_id
+        .inline-form
+          = ff.input :display, wrapper_html: { class: 'col-md-3' }
+          = ff.input :position, wrapper_html: { class: 'col-md-3' }
+          = ff.input :name
+          = ff.hidden_field :session_format_id
+
+      %div{"data-controller": "nested-form"}
+        %h4 Fonts
+        %template{"data-nested-form-target": "template"}
+          = f.simple_fields_for :fonts,
+            Website::Font.new,
+            child_index: 'NEW_RECORD' do |font|
+            = render 'font_fields', form: font
+        = f.simple_fields_for :fonts do |font|
+          = render 'font_fields', form: font
+        %div{"data-nested-form-target": "links"}
+          = link_to "Add Font", "#", class: 'btn btn-success',
+            data: { action: "click->nested-form#add_association" }
 
   .row
     .col-sm-12

--- a/db/migrate/20220506044703_create_table_website_fonts.rb
+++ b/db/migrate/20220506044703_create_table_website_fonts.rb
@@ -1,0 +1,12 @@
+class CreateTableWebsiteFonts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :website_fonts do |t|
+      t.string :name
+      t.boolean :primary
+      t.boolean :secondary
+      t.belongs_to :website
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_04_213512) do
+ActiveRecord::Schema.define(version: 2022_05_06_044703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,6 +335,16 @@ ActiveRecord::Schema.define(version: 2022_05_04_213512) do
     t.datetime "created_at"
     t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  create_table "website_fonts", force: :cascade do |t|
+    t.string "name"
+    t.boolean "primary"
+    t.boolean "secondary"
+    t.bigint "website_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["website_id"], name: "index_website_fonts_on_website_id"
   end
 
   create_table "websites", force: :cascade do |t|

--- a/spec/features/website/schedule_spec.rb
+++ b/spec/features/website/schedule_spec.rb
@@ -43,16 +43,16 @@ feature "dynamic website schedule page" do
     visit schedule_path(event)
 
     expect(page).to have_content(time_slot.title)
-    click_on(event.conference_date(2).strftime("%B %e"))
+    click_on(event.conference_date(2).strftime("%B %-e"))
 
     expect(page)
-      .to have_link(event.conference_date(2).strftime("%B %e"), class: "selected")
+      .to have_link(event.conference_date(2).strftime("%B %-e"), class: "selected")
     expect(page).to_not have_content(time_slot.title)
     time_slot.update(conference_day: 2)
 
     visit schedule_path(event)
     expect(page).to_not have_content(time_slot.title)
-    click_on(event.conference_date(2).strftime("%B %e"))
+    click_on(event.conference_date(2).strftime("%B %-e"))
 
     expect(page).to have_content(time_slot.title)
   end


### PR DESCRIPTION


Title

Reason for Change
=================
From Miro Card: 
>As a designer, I want to be able to change the typography of the site. This might involve a primary and a secondary typeface. I want changes I make in one place to be reflected across the whole site, both in static and dynamic pages.

This PR introduces a new model to capture information about website fonts and store typeface files. These font files are then dynamically loaded into the head using style tags.

Also, a new  StimulusJS `nested_form_controller` was added to help manage adding, editing and removing of fonts nested in the Website configuration form page. This was mostly stolen from [GoRails](https://github.com/gorails-screencasts/dynamic-nested-forms-with-stimulusjs/blob/master/app/javascript/controllers/nested_form_controller.js) with a little addition for grouping checkboxes to ensure only one primary or secondary font is selected at a time. 

Right now we are only have one font being used but a secondary one can now be added. Other additional fonts can be added and then potentially used dynamically using tailwind in static pages using [arbitrary values](https://tailwindcss.com/docs/font-family#arbitrary-values).

Changes
=======
- creates Website::Font model with has_many association to website
- adds ability to upload multiple fonts using nested-form stimulus
  controller
- adds css styles in heads for including font-face for website fonts and
  setting root font variables
- adds ability to group checkboxes in nested form so that only one is
  selected

Minor
====
- fixes strftime format for schedule dates to skip padding appease
  Capybara

[Change the typography of the site](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523893333023&cot=14)
