### PR TITLE
Basic metadata for SEO

### DIFF
--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -37,6 +37,7 @@ class Staff::WebsitesController < Staff::ApplicationController
       .permit(
         :logo,
         :background,
+        :favicon,
         :city,
         :location,
         :directions,
@@ -59,6 +60,9 @@ class Staff::WebsitesController < Staff::ApplicationController
         contents_attributes: [
           :id, :name, :html, :placement, :_destroy
         ],
+        meta_data_attributes: [
+          :id, :title, :author, :description, :image
+        ]
     )
   end
 end

--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -1,5 +1,6 @@
 class WebsiteDecorator < ApplicationDecorator
   delegate_all
+  delegate :title, :author, :description, to: :meta_data
 
   DEFAULT_LINKS = {
     'Schedule' => 'schedule',
@@ -142,5 +143,22 @@ class WebsiteDecorator < ApplicationDecorator
 
   def footer_content
     object.contents.for(Website::Content::FOOTER).pluck(:html).join.html_safe
+  end
+
+  def meta_data
+    @meta_data ||= object.meta_data || object.build_meta_data
+  end
+
+  def meta_image_url
+    attachment = meta_data.image.attached? ? meta_data.image : logo
+    h.polymorphic_url(attachment) if attachment.attached?
+  end
+
+  def website_title(page_title)
+    [page_title, title].reject(&:blank?).join(" | ")
+  end
+
+  def favicon_url
+    h.polymorphic_url(favicon) if favicon.attached?
   end
 end

--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -7,4 +7,17 @@ module ImageHelper
       image_tag(image.variant(resize_to_fit: [width, height]))
     end
   end
+
+  def image_input(form, field, width: 100)
+    image = form.object.send(field)
+    title = field.to_s.titleize
+    attached = image.attached?
+    input = ""
+    if attached
+      input << form.label(field, "Current #{title}", class: "control-label")
+      input << content_tag(:div, resize_image_tag(image, width: width))
+    end
+    input << form.input(field, label: attached ? "Replace #{title}" : "#{title}")
+    input.html_safe
+  end
 end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -3,16 +3,20 @@ class Website < ApplicationRecord
   has_many :pages, dependent: :destroy
   has_many :fonts, class_name: 'Website::Font', dependent: :destroy
   has_many :contents, class_name: 'Website::Content', dependent: :destroy
+  has_one :meta_data, class_name: 'Website::MetaData', dependent: :destroy
 
   has_many :session_formats, through: :event
   has_many :session_format_configs
 
+
   accepts_nested_attributes_for :fonts, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :contents, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :meta_data
   accepts_nested_attributes_for :session_format_configs
 
   has_one_attached :logo
   has_one_attached :background
+  has_one_attached :favicon
 
   DEFAULT = 'default'.freeze
 

--- a/app/models/website/meta_data.rb
+++ b/app/models/website/meta_data.rb
@@ -1,0 +1,11 @@
+class Website::MetaData < ApplicationRecord
+  belongs_to :website
+  after_initialize :defaults
+
+  has_one_attached :image
+
+  def defaults
+    self.title ||= website.event.name
+    self.description ||= website.event.name
+  end
+end

--- a/app/views/layouts/themes/default.html.haml
+++ b/app/views/layouts/themes/default.html.haml
@@ -1,8 +1,24 @@
 !!!5
 %html(lang="en")
   %head
-    %title= title
+    %title= current_website.website_title(yield(:title))
+    %link{rel: "icon", type: "image/png", href: current_website.favicon_url}
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
+
+    %meta{property: "og:title", content: current_website.website_title(yield(:title))}
+    %meta{property: "og:author", content: current_website.author}
+    %meta{property: "og:url", content: request.original_url}
+    %meta{property: "og:type", content: "website"}
+    %meta{property: "og:description", content: current_website.description}
+    %meta{property: "og:image", content: current_website.meta_image_url}
+
+    %meta{property: "twitter:card", content: "summary_large_image"}
+    %meta{property: "twitter:site", content: "@#{current_website.twitter_handle}"}
+    %meta{property: "twitter:title", content: current_website.website_title(yield(:title))}
+    %meta{property: "twitter:url", content: request.original_url}
+    %meta{property: "twitter:description", content: current_website.description}
+    %meta{property: "twitter:image", content: current_website.meta_image_url}
+
     = stylesheet_link_tag current_website.theme, media: 'all'
     = javascript_pack_tag "application"
     :css

--- a/app/views/pages/show.html.haml
+++ b/app/views/pages/show.html.haml
@@ -1,1 +1,2 @@
+- content_for(:title) { @page&.name }
 = embed(@body)

--- a/app/views/programs/show.html.haml
+++ b/app/views/programs/show.html.haml
@@ -1,4 +1,4 @@
-
+- content_for(:title) { "Program" }
 .program-page-wrapper{ data: { 'controller': 'sub-nav fly-out', 'sub-nav-displayed-id-value': "#{current_website.default_session_slug}", 'fly-out-revealed-element-value': 'inital' } }
   = render 'fly_out', collection: @program_sessions
   %h3.page-title

--- a/app/views/schedule/show.html.haml
+++ b/app/views/schedule/show.html.haml
@@ -1,4 +1,4 @@
-
+- content_for(:title) { "Schedule" }
 .schedule-page-wrapper{ data: { 'controller': 'sub-nav', 'sub-nav-displayed-id-value': 'schedule-day-one' } }
   %nav.sub-nav
     %ul

--- a/app/views/sponsors/show.html.haml
+++ b/app/views/sponsors/show.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title) { "Sponsors" }
 %div.sponsors-page-wrapper
   %h3
     Sponsors
@@ -10,4 +11,4 @@
         .sponsors-wrapper
           = render sponsors
 
-  %div{ data: { 'controller': 'banner-ads', 'banner-ads-event-slug-value': 'railsconf-2022', 'banner-ads-index-value': '0' } }
+  = embed(content_tag("sponsors-banner-adds"))

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -1,17 +1,9 @@
 = simple_form_for website, url: :event_staff_website do |f|
   .row
     %fieldset.col-md-6
-      - if website.logo.attached?
-        = f.label :logo, "Current Logo", class: "control-label"
-        %div
-          = resize_image_tag(website.logo, width: 100)
-      = f.input :logo, label: website.logo.attached? ? "Replace Logo" : "Logo"
-      - if website.background.attached?
-        = f.label :background, "Current Background", class: "control-label"
-        %div
-          = resize_image_tag(website.background, width: 200)
-      = f.input :background,
-        label: website.background.attached? ? "Replace Background" : "Background"
+      = image_input(f, :logo)
+      = image_input(f, :background)
+      = image_input(f, :favicon)
       = f.input :city
       = f.input :location, as: :text
       = f.input :directions
@@ -71,6 +63,11 @@
           = link_to "Add Content", "#", class: 'btn btn-success',
             data: { action: "click->nested-form#add_association" }
 
+      %h4 Meta Data
+      = f.simple_fields_for :meta_data, website.meta_data do |ff|
+        = ff.input :title
+        = ff.input :author
+        = ff.input :description
   .row
     .col-sm-12
       = submit_tag("Save", class: "pull-right btn btn-success", type: "submit")

--- a/db/migrate/20220508071747_create_website_meta_data.rb
+++ b/db/migrate/20220508071747_create_website_meta_data.rb
@@ -1,0 +1,12 @@
+class CreateWebsiteMetaData < ActiveRecord::Migration[6.1]
+  def change
+    create_table :website_meta_data do |t|
+      t.string :title
+      t.string :author
+      t.text :description
+      t.belongs_to :website, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_07_081350) do
+ActiveRecord::Schema.define(version: 2022_05_08_071747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -357,6 +357,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_081350) do
     t.index ["website_id"], name: "index_website_fonts_on_website_id"
   end
 
+  create_table "website_meta_data", force: :cascade do |t|
+    t.string "title"
+    t.string "author"
+    t.text "description"
+    t.bigint "website_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["website_id"], name: "index_website_meta_data_on_website_id"
+  end
+
   create_table "websites", force: :cascade do |t|
     t.bigint "event_id"
     t.datetime "created_at", precision: 6, null: false
@@ -384,5 +394,6 @@ ActiveRecord::Schema.define(version: 2022_05_07_081350) do
   add_foreign_key "session_format_configs", "websites"
   add_foreign_key "session_formats", "events"
   add_foreign_key "sponsors", "events"
+  add_foreign_key "website_meta_data", "websites"
   add_foreign_key "websites", "events"
 end

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -68,6 +68,7 @@ feature "Website Configuration" do
       </script>
       HTML
     )
+    fill_in("City", with: "Big Red")
     click_on("Save")
 
     visit edit_event_staff_page_path(event, home_page)


### PR DESCRIPTION
Reason for Change
=================
 
From Miro Story: 
>Current site includes opengraph (prefixed og:) metadata and twitter metadata. Title tags should be distinct and based on the page name.

At first I was considering a more flexible approach to adding metadata tags but in the end that was going to not be worth the complexity. This approach provides inputs for the minimal needed information to duplicate the current tags represented in the old railsconf layout.

Changes
- adds Website::MetaData for storing information to populate og and
  twitter meta tags
- adds Website#favicon attachment
- refactors image input to helper method
- adds title to dynamic and static pages

[Basic metadata for SEO](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764523894399447&cot=14)