### PR TITLE
Website fonts and pages bugfixes

### DIFF
--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -1,4 +1,5 @@
 class Staff::PagesController < Staff::ApplicationController
+  before_action :require_website
   before_action :enable_website_subnav
   before_action :set_page, except: :index
   before_action :authorize_page, except: :index
@@ -97,5 +98,12 @@ class Staff::PagesController < Staff::ApplicationController
         :footer_category,
         :unpublished_body
       )
+  end
+
+  def require_website
+    return if current_website
+
+    redirect_to new_event_staff_website_path(current_event),
+      alert: "Please configure your website before attempting to create pages"
   end
 end

--- a/app/controllers/staff/websites_controller.rb
+++ b/app/controllers/staff/websites_controller.rb
@@ -6,19 +6,25 @@ class Staff::WebsitesController < Staff::ApplicationController
   def new; end
 
   def create
-    @website.update(website_params)
-
-    flash[:success] = "Website was successfully created."
-    redirect_to edit_event_staff_website_path(current_event)
+    if @website.update(website_params)
+      flash[:success] = "Website was successfully created."
+      redirect_to edit_event_staff_website_path(current_event)
+    else
+      flash[:warning] = "There were errors creating your website configuration"
+      render :new
+    end
   end
 
   def edit; end
 
   def update
-    @website.update(website_params)
-
-    flash[:success] = "Website was successfully updated."
-    redirect_to edit_event_staff_website_path(current_event)
+    if @website.update(website_params)
+      flash[:success] = "Website was successfully updated."
+      redirect_to edit_event_staff_website_path(current_event)
+    else
+      flash[:warning] = "There were errors updating your website configuration"
+      render :edit
+    end
   end
 
   private

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -8,8 +8,9 @@ class Website < ApplicationRecord
   has_many :session_formats, through: :event
   has_many :session_format_configs
 
-
-  accepts_nested_attributes_for :fonts, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :fonts,
+    reject_if: ->(font) { font['name'].blank? && font['file'].blank? },
+    allow_destroy: true
   accepts_nested_attributes_for :contents, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :meta_data
   accepts_nested_attributes_for :session_format_configs

--- a/app/models/website/font.rb
+++ b/app/models/website/font.rb
@@ -3,6 +3,8 @@ class Website::Font < ApplicationRecord
 
   has_one_attached :file
 
+  validates :file, :name, presence: true
+
   scope :primary, -> { where(primary: true) }
   scope :secondary, -> { where(secondary: true) }
 end

--- a/app/views/staff/websites/_form.html.haml
+++ b/app/views/staff/websites/_form.html.haml
@@ -40,8 +40,8 @@
           = ff.input :name
           = ff.hidden_field :session_format_id
 
-      %div{"data-controller": "nested-form"}
-        %legend.fieldset-legend Fonts
+      %div{"data-controller": "nested-form", class: "nested-fonts"}
+        %h4 Fonts
         %template{"data-nested-form-target": "template"}
           = f.simple_fields_for :fonts,
             Website::Font.new,

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -47,6 +47,26 @@ feature "Website Configuration" do
     expect(current_path).to eq('/home')
   end
 
+  scenario "Organizer fails to add font file correctly", :js do
+    website = create(:website, event: event)
+
+    login_as(organizer)
+    visit edit_event_staff_website_path(event)
+
+    click_on("Add Font")
+    click_on("Save")
+    expect(page).to have_content("Website was successfully updated")
+
+    expect(website.fonts.count).to eq(0)
+
+    click_on("Add Font")
+    within(".nested-fonts") { fill_in("Name", with: "Times") }
+    click_on("Save")
+
+    expect(page).to have_content("There were errors updating your website configuration")
+    within(".nested-fonts") { expect(page).to have_content("can't be blank") }
+  end
+
   scenario "Organizer configures tailwind with head content", :js do
     website = create(:website, event: event)
     home_page = create(:page, website: website)

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -5,6 +5,19 @@ feature "Website Page Management" do
   let(:organizer) { create(:organizer, event: event) }
   let!(:website) { create(:website, :with_details, event: event) }
 
+  scenario "Organizer cannot access pages until website is created" do
+    website.destroy
+    login_as(organizer)
+
+    visit event_path(event)
+    within('.navbar') { click_on("Website") }
+    within('.website-subnav') { click_on("Pages") }
+
+    expect(page).to have_content(
+      "Please configure your website before attempting to create pages"
+    )
+  end
+
   scenario "Organizer creates and edits a website page", :js do
     login_as(organizer)
 


### PR DESCRIPTION
Reason for Change
=================
This PR addresses some issues that arose during early testing of website configuration and page creation. 

Changes
=======
- skips font creation when name and file are blank
- adds validation to ensure font name and file are present
- renders :new and :edit with flash message when creating and updating
  fail
- redirects to new website page with message when accessing pages before
  website is configured
- adds regression specs for above scenarios

Title
