### PR TITLE
Navigation link ordering does not persist

### DIFF
--- a/app/decorators/website_decorator.rb
+++ b/app/decorators/website_decorator.rb
@@ -82,7 +82,7 @@ class WebsiteDecorator < ApplicationDecorator
     @link_options ||= pages.published.pluck(:name, :slug)
       .each_with_object(DEFAULT_LINKS.dup) do |(name, slug), memo|
       memo[name] = slug
-    end
+    end.sort_by { |_key, value| navigation_links.index(value) || 0 }.to_h
   end
 
   def tracks

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -44,7 +44,7 @@ feature "Website Configuration" do
 
     click_on(home_page.name, match: :first)
 
-    expect(current_path).to eq('/home')
+    expect(current_path).to eq("/#{home_page.slug}")
   end
 
   scenario "Organizer fails to add font file correctly", :js do

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -108,14 +108,14 @@ feature "Website Page Management" do
 
   scenario "Organizer hides navigation to a page and hides a page entirely", :js do
     home_page = create(:page, published_body: 'Home Content')
-    website.update(navigation_links: [home_page.slug])
+    website.update(navigation_links: [home_page.slug, "schedule"])
     visit page_path(slug: event.slug, page: home_page.slug)
-    expect(page).to have_content('Home Content')
-    within('#main-nav') { expect(page).to have_link(home_page.name) }
+    within('#main-nav') { expect(page).to have_content(home_page.name) }
 
     login_as(organizer)
     visit edit_event_staff_website_path(event)
-    find_field('Navigation links').send_keys(:backspace)
+    expect(page).to have_content("Navigation links\nHomeSchedule")
+    find_field('Navigation links').send_keys(:backspace).send_keys(:backspace)
     fill_in('Navigation links', with: "Schedule\n")
     click_on("Save")
 


### PR DESCRIPTION

Reason for Change
=================
Devon noticed the following buggy behavior: 

>This is a small thing that I've noticed - doesn't seem to impact the published page (which is good). I keep trying to reorder "Home" to be the first link in the nav. Click save. See published page and notice "Home" is where I expect (good). Then, I go back to the config page and see that Home has decided to reorder itself again. Just a weird blip of thing - but not too big of a deal." ~Devon in Slack 5/11

While the order was being persisted in the database the link options were reordering the selectize values which would have unintentionally reordered the navigation links on a subsequent save. This PR makes sure that the link options match the order of the selected links so that selectize does not reorder them. 

Changes
=======
- orders link options by the navigation link order to ensure that order
  of selected options are preserved across saves
- fixes flaky feature website/configuration_spec.rb to be more explicit
  about slug path

[Navigation link ordering does not persist](https://miro.com/app/board/uXjVO6C1LxA=/?moveToWidget=3458764525170508650&cot=14)