### PR TITLE
add body_published_at to pages table

### DIFF
--- a/app/controllers/staff/pages_controller.rb
+++ b/app/controllers/staff/pages_controller.rb
@@ -39,7 +39,8 @@ class Staff::PagesController < Staff::ApplicationController
   def preview; end
 
   def publish
-    @page.update(published_body: @page.unpublished_body)
+    @page.update(published_body: @page.unpublished_body,
+                 body_published_at: Time.current)
     flash[:success] = "#{@page.name} Page was successfully published."
     redirect_to event_staff_pages_path(current_event)
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,6 +33,10 @@ class Page < ApplicationRecord
   def self.from_template(key, attrs)
     new(TEMPLATES[key].merge(template: key, name: key.titleize, slug: key, **attrs))
   end
+
+  def unpublished_changes?
+    published_body != unpublished_body
+  end
 end
 
 # == Schema Information

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,7 +4,8 @@ class Page < ApplicationRecord
     'home' => { },
   }
 
-  belongs_to :website, touch: :purged_at
+  belongs_to :website
+  after_save_commit :purge_website_cache
 
   scope :published, -> { where.not(published_body: nil).where(hide_page: false) }
   scope :in_footer, -> { published.where.not(footer_category: [nil, ""]) }
@@ -36,6 +37,12 @@ class Page < ApplicationRecord
 
   def unpublished_changes?
     published_body != unpublished_body
+  end
+
+  private
+
+  def purge_website_cache
+    website.save
   end
 end
 

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -21,7 +21,6 @@ class Website < ApplicationRecord
   has_one_attached :background
   has_one_attached :favicon
 
-  after_touch :purge_cache, if: :caching_automatic?
   around_update :purge_cache, if: :caching_automatic?
 
   DEFAULT = 'default'.freeze
@@ -34,11 +33,9 @@ class Website < ApplicationRecord
     purge_cache { save }
   end
 
-  private
-
   def purge_cache
     self.purged_at = Time.current
-    yield if block_given?
+    yield
     FastlyService.service&.purge_by_key(event.slug)
   end
 end

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -8,7 +8,7 @@
     - if page.published?
       = time_ago_in_words(page.body_published_at)
     - else
-      Not Published
+      %span.label-warning Not Published
   %td
     - if page.unpublished_changes?
       %span.glyphicon.glyphicon-bell

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -5,6 +5,14 @@
     - if page.published?
       %span.glyphicon.glyphicon-ok
   %td
+    - if page.published?
+      = time_ago_in_words(page.body_published_at)
+    - else
+      Not Published
+  %td
+    - if page.unpublished_changes?
+      %span.glyphicon.glyphicon-bell
+  %td
     - if page.landing?
       %span.glyphicon.glyphicon-ok
   %td

--- a/app/views/staff/pages/_page.html.haml
+++ b/app/views/staff/pages/_page.html.haml
@@ -6,7 +6,7 @@
       %span.glyphicon.glyphicon-ok
   %td
     - if page.published?
-      = time_ago_in_words(page.body_published_at)
+      = time_ago_in_words(page.body_published_at || page.updated_at)
     - else
       %span.label-warning Not Published
   %td

--- a/app/views/staff/pages/index.html.haml
+++ b/app/views/staff/pages/index.html.haml
@@ -14,6 +14,8 @@
           %th Name
           %th Slug
           %th Published
+          %th Last Published
+          %th Unpublished Changes
           %th Landing Page
           %th
             Actions

--- a/db/migrate/20220523185412_add_body_published_at_to_pages.rb
+++ b/db/migrate/20220523185412_add_body_published_at_to_pages.rb
@@ -1,0 +1,5 @@
+class AddBodyPublishedAtToPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pages, :body_published_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_134224) do
+ActiveRecord::Schema.define(version: 2022_05_23_185412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2022_05_12_134224) do
     t.boolean "hide_footer", default: false, null: false
     t.boolean "hide_page", default: false, null: false
     t.string "footer_category"
+    t.datetime "body_published_at"
     t.index ["website_id"], name: "index_pages_on_website_id"
   end
 

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:slug) { |i| "home#{i if i > 1}" }
     unpublished_body { "<p>#{Faker::Lorem.paragraph}</p>" }
     published_body { "<p>#{Faker::Lorem.paragraph}</p>" }
+    body_published_at { DateTime.now - 1.day }
   end
 end


### PR DESCRIPTION
🟡  - Ready for Review

Reason for Change
=================
As a website editor I would like to know when a page was last edited, and which pages have updates that have yet to be published

Changes
=======
- add body_published_at column to the pages table.
- when a page is published, set the value of body_published_at.
- If a page has unpublished changes, display this on the index with an icon.

Who Doesn't Love a Preview
=====================
![Screen Recording 2022-05-23 at 3 09 21 PM](https://user-images.githubusercontent.com/71521423/169906768-248e0bbc-9c16-4318-8b4d-45c451ec5b16.gif)
