### PR TITLE
indicate sponsored time slots on time slot index

### DIFF
--- a/app/decorators/staff/time_slot_decorator.rb
+++ b/app/decorators/staff/time_slot_decorator.rb
@@ -20,7 +20,7 @@ class Staff::TimeSlotDecorator < Draper::Decorator
 
  def row_data_time_sortable(buttons: false)
    row = [object.conference_day, object.start_time, object.end_time, linked_title,
-     display_presenter, object.room_name, display_track_name]
+     display_presenter, object.room_name, display_sponsor_star, display_track_name]
      row << action_links if buttons
      row
  end
@@ -140,6 +140,10 @@ class Staff::TimeSlotDecorator < Draper::Decorator
 
   def sponsored?
     object.sponsor.present?
+  end
+
+  def display_sponsor_star
+    h.content_tag(:span, "", class: "glyphicon glyphicon-star") if sponsored?
   end
 
   def preview_css

--- a/app/views/staff/time_slots/_time_slots.html.haml
+++ b/app/views/staff/time_slots/_time_slots.html.haml
@@ -43,6 +43,7 @@
             %th Title
             %th Presenter
             %th Room
+            %th Sponsor
             %th Track
             %th.actions Actions
         %tbody


### PR DESCRIPTION
Reason for Change
=================
In order for an event organizer to better track which time slots are assigned sponsors, include a sponsor star on the time slot index page

Changes
=======
* Minimal changes. 1 method in the decorator

Quick Preview
===========
<img width="1392" alt="time slot index" src="https://user-images.githubusercontent.com/71521423/169968511-d320be5a-0b30-40b7-8955-e06dacdeca84.png">

