### PR TITLE
Change set_cache_headers to before_action

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,7 @@
 class PagesController < ApplicationController
   before_action :require_website, only: :show
   before_action :require_page, only: :show
-
-  after_action :set_cache_headers, only: :show
+  before_action :set_cache_headers, only: :show
 
   def current_styleguide
   end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,7 +1,6 @@
 class ProgramsController < ApplicationController
   before_action :require_website
-
-  after_action :set_cache_headers, only: :show
+  before_action :set_cache_headers, only: :show
 
   def show
     @program_sessions = current_website.event.program_sessions.live

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,8 +1,7 @@
 class ScheduleController < ApplicationController
   include WebsiteScheduleHelper
   before_action :require_event
-
-  after_action :set_cache_headers, only: :show
+  before_action :set_cache_headers, only: :show
 
   decorates_assigned :schedule, with: Staff::TimeSlotDecorator
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -1,7 +1,6 @@
 class SponsorsController < ApplicationController
   before_action :require_website
-
-  after_action :set_cache_headers, only: :show
+  before_action :set_cache_headers, only: :show
 
   def show
     @sponsors_by_tier = Sponsor.published.order_by_tier.group_by(&:tier)

--- a/spec/features/website/page_viewing_spec.rb
+++ b/spec/features/website/page_viewing_spec.rb
@@ -59,4 +59,13 @@ feature 'Public Page Viewing' do
     visit landing_path(slug: website.event.slug)
     expect(page).to have_content("Page Not Found")
   end
+
+  scenario 'Public views a cached page twice and gets 304 without rendering', :caching, :js do
+    website.update(caching: :automatic)
+    create(:page, published_body: 'Home Content', landing: true)
+
+    expect_any_instance_of(PagesController).to receive(:show).once.and_call_original
+    visit landing_path(slug: website.event.slug)
+    visit landing_path(slug: website.event.slug)
+  end
 end


### PR DESCRIPTION
Reason for Change
=================
- While working on a blog post about caching for cfp-app website pages it occurred to be that `set_cache_headers` should really be called before the controller action to save on server resources and increase the cached response speed when it turns out that the website has not been modified as determined by the call to `fresh_when`. In that case the 304 Not Modified response should go out as soon as possible. 

Changes
=======
- should be done before rendering to save server resources when
  fresh_when renders head 304
- adds spec to confirm that pages#show does not get called once cached
