### PR TITLE
Bug-Fixes

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -4,7 +4,7 @@ class ProgramsController < ApplicationController
   after_action :set_cache_headers, only: :show
 
   def show
-    @program_sessions = current_website.event.program_sessions.live
+    @program_sessions = current_website.program_sessions.live
     render layout: "themes/#{current_website.theme}"
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,13 +1,12 @@
 class ScheduleController < ApplicationController
   include WebsiteScheduleHelper
-  before_action :require_event
-
   after_action :set_cache_headers, only: :show
 
   decorates_assigned :schedule, with: Staff::TimeSlotDecorator
 
   def show
-    @schedule = current_event.time_slots.grid_order.includes(:room, program_session: { proposal: {speakers: :user}})
+    @schedule = current_website.time_slots.grid_order
+      .includes(:room, program_session: { proposal: {speakers: :user}})
     render layout: "themes/#{current_website.theme}"
   end
 end

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -4,7 +4,7 @@ class SponsorsController < ApplicationController
   after_action :set_cache_headers, only: :show
 
   def show
-    @sponsors_by_tier = Sponsor.published.order_by_tier.group_by(&:tier)
+    @sponsors_by_tier = current_website.sponsors.published.order_by_tier.group_by(&:tier)
     render layout: "themes/#{current_website.theme}"
   end
 end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -51,7 +51,7 @@ export default class extends Controller {
       mode: "htmlmixed",
       lineWrapping: true,
     });
-    for (var i=0;i<editor.lineCount();i++) { editor.indentLine(i); }
+    indentCodeMirror(editor);
     editor.on('change', (e) => {
       this.changedValue = true;
       this.preview(e.getValue());
@@ -61,6 +61,10 @@ export default class extends Controller {
       this.uploadFile(event.dataTransfer.files[0], event, e)
     })
     return editor;
+  }
+
+  indentCodeMirror(editor) {
+    for (var i=0;i<editor.lineCount();i++) { editor.indentLine(i); }
   }
 
   preview(content) {

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -2,6 +2,9 @@ class Website < ApplicationRecord
   enum caching: { off: 'off', automatic: 'automatic', manual: 'manual' }, _prefix: true
 
   belongs_to :event
+  has_many :sponsors, through: :event
+  has_many :time_slots, through: :event
+  has_many :program_sessions, through: :event
   has_many :pages, dependent: :destroy
   has_many :fonts, class_name: 'Website::Font', dependent: :destroy
   has_many :contents, class_name: 'Website::Content', dependent: :destroy

--- a/spec/features/website/schedule_spec.rb
+++ b/spec/features/website/schedule_spec.rb
@@ -111,4 +111,10 @@ feature "dynamic website schedule page" do
       end
     end
   end
+
+  scenario 'Public views schedule page on custom domain' do
+    website.update(domains: 'www.example.com')
+    visit schedule_path
+    expect(current_path).to eq('/schedule')
+  end
 end

--- a/spec/features/website/sponsor_spec.rb
+++ b/spec/features/website/sponsor_spec.rb
@@ -60,5 +60,11 @@ feature 'Wesite displays an events sponsors' do
       expect(page).to_not have_content(sponsor.offer_text)
       expect(page).to_not have_content(sponsor.offer_headline)
     end
+
+    it "Only displays sponsors for the website event" do
+      sponsor = create(:sponsor, event: create(:event))
+      visit sponsors_path(event)
+      expect(page).not_to have_content(sponsor.description)
+    end
   end
 end


### PR DESCRIPTION
Reason for Change
=================
While working on Loom videos I uncovered some critical bugs. Sponsors were not being scoped to the website/event. Clearly that would have eventually been discovered but it is nice to catch it now. A trickier bug was the on the schedule page which could not be accessed when using the custom domain because it was requiring an event. In general it is best to go through `current_website` for website pages since it contains all the logic to determine the correct website/event based on the domain, slugs and routes. These fixes are backed by feature specs to prevent regressions. 

Finally, there is a bug fix for the problem that Devon identified in which indenting is lost when switching between TinyMCE and CodeMirror. 

Changes
=======
- scopes sponsors to current event on sponsors page
- retrieves schedule through website rather than event to support custom
  domain access to schedule page
- fixes indenting when going back from TinyMCE and CodeMirror

