### PR TITLE
Fixes bug with matching website with multiple domains configured

### DIFF
--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -26,7 +26,7 @@ class Website < ApplicationRecord
   DEFAULT = 'default'.freeze
 
   def self.domain_match(domain)
-    where(arel_table[:domains].matches("%#{(domain)}"))
+    where(arel_table[:domains].matches("%#{domain}%"))
   end
 
   def manual_purge

--- a/spec/models/website_spec.rb
+++ b/spec/models/website_spec.rb
@@ -11,6 +11,7 @@ describe Website do
       rubyconf = create(:website, domains: 'www.rubyconf.org,www.rubyconf.com')
       _otherconf = create(:website)
       expect(Website.domain_match('rubyconf.com')).to contain_exactly(rubyconf)
+      expect(Website.domain_match('rubyconf.org')).to contain_exactly(rubyconf)
     end
   end
 end


### PR DESCRIPTION

Reason for Change
=================
While configuring domains for rubyconf it was discovered that only the last domain in the list was being matched correctly which revealed the bug in the Postgres match string.

Changes
=======
- adds wildcard to the end of the ILIKE match string and removes
  unneeded parens around interpolated domain
