### PR TITLE
Specify Heroku buildpack 'heroku-20'

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,5 @@
 {
+  "stack": "heroku-20",
   "name": "CFP-App",
   "description": "Conference call for proposal management application by Ruby Central",
   "keywords": [


### PR DESCRIPTION
Title

Reason for Change
=================
* After upgrading to Ruby 3.0.4 and upgrading via dashboard to `heroku-22` buildpack, the build failed.
* That version of Ruby is only in `heroku-20`.

Changes
=======
* Specify the buildpack in `app.json`

Documentation
=============
* https://devcenter.heroku.com/articles/heroku-20-stack#using-heroku-20
