### PR TITLE
Changes to DomainContraint to prevent database call per request

### DIFF
--- a/app/constraints/domain_constraint.rb
+++ b/app/constraints/domain_constraint.rb
@@ -1,0 +1,7 @@
+class DomainConstraint
+  def matches?(request)
+    return false unless request.domain
+
+    !Rails.configuration.events_hosts.match?(request.domain)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,10 +116,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def require_website
-    redirect_to not_found_path and return unless current_website
-  end
-
   def require_proposal
     @proposal = @event.proposals.find_by!(uuid: params[:proposal_uuid] || params[:uuid])
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,9 @@ module CFPApp
     config.active_record.time_zone_aware_types = [:datetime]
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.events_hosts = ENV.fetch('EVENTS_HOSTS') do
+      'localhost,example.com,herokuapp.com'
+    end
   end
 end

--- a/config/initializers/domain_constraint.rb
+++ b/config/initializers/domain_constraint.rb
@@ -1,5 +1,0 @@
-class DomainConstraint
-  def matches?(request)
-    Website.domain_match(request.domain).exists?
-  end
-end

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -20,9 +20,11 @@ feature "Website Configuration" do
     website = create(:website, event: event)
     home_page = create(:page, website: website)
 
-    visit("/#{home_page.slug}")
+    with_domain('lvh.me') do
+      visit("/#{home_page.slug}")
 
-    expect(current_path).to eq(not_found_path)
+      expect(current_path).to eq(not_found_path)
+    end
 
     login_as(organizer)
     visit event_path(website.event)
@@ -30,7 +32,7 @@ feature "Website Configuration" do
 
     expect(page).to have_content("Edit Website")
 
-    fill_in('Domains', with: 'www.example.com')
+    fill_in('Domains', with: 'lvh.me')
     fill_in('Navigation links', with: "Home\n")
     click_on("Save")
 
@@ -38,13 +40,15 @@ feature "Website Configuration" do
 
     logout
 
-    visit("/#{home_page.slug}")
+    with_domain('lvh.me') do
+      visit("/#{home_page.slug}")
 
-    expect(page).to have_content(strip_tags(home_page.published_body))
+      expect(page).to have_content(strip_tags(home_page.published_body))
 
-    click_on(home_page.name, match: :first)
+      click_on(home_page.name, match: :first)
 
-    expect(current_path).to eq("/#{home_page.slug}")
+      expect(current_path).to eq("/#{home_page.slug}")
+    end
   end
 
   scenario "Organizer fails to add font file correctly", :js do

--- a/spec/features/website/page_viewing_spec.rb
+++ b/spec/features/website/page_viewing_spec.rb
@@ -20,25 +20,27 @@ feature 'Public Page Viewing' do
     expect(page).to have_content('Home Content')
   end
 
-  context 'when using a custom domain' do
-    scenario 'Public views the landing page from custom domain' do
-      website.update(domains: 'www.example.com')
+  scenario 'Public views the landing page from custom domain', js: true do
+    with_domain('lvh.me') do
+      website.update(domains: 'www.lvh.me')
       create(:page, published_body: 'Home Content', landing: true)
       visit root_path
 
       expect(page).to have_content('Home Content')
     end
+  end
 
-    scenario 'Public views the landing page for an older website on custom domain' do
-      website.update(domains: 'www.example.com')
+  scenario 'Public views the landing page for an older website on custom domain', js: true do
+    with_domain('lvh.me') do
+      website.update(domains: 'www.lvh.me')
       old_home_page = create(:page, published_body: 'Old Website', landing: true)
       website.update(navigation_links: [old_home_page.slug])
 
-      new_website = create(:website, domains: 'www.example.com')
+      new_website = create(:website, domains: 'www.lvh.me')
       new_home_page = create(:page,
-                             website: new_website,
-                             published_body: 'New Website',
-                             landing: true)
+                            website: new_website,
+                            published_body: 'New Website',
+                            landing: true)
 
       new_website.update(navigation_links: [new_home_page.slug])
       visit root_path
@@ -53,12 +55,12 @@ feature 'Public Page Viewing' do
       click_on(old_home_page.name, match: :first)
       expect(page).to have_content('Old Website')
     end
+  end
 
-    scenario 'Public gets not found message for wrong path on subdomain' do
-      website.update(domains: 'www.example.com')
+  scenario 'Public gets not found message for wrong path on subdomain' do
+    website.update(domains: 'www.example.com')
 
-      visit landing_path(slug: website.event.slug)
-      expect(page).to have_content("Page Not Found")
-    end
+    visit landing_path(slug: website.event.slug)
+    expect(page).to have_content("Page Not Found")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,3 +93,5 @@ def save_timestamped_screenshot(page)
 
   page.save_screenshot(screenshot_path)
 end
+
+Capybara.always_include_port = true

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,9 @@
 require 'support/helpers/session_helpers'
 require 'support/helpers/form_helpers'
+require 'support/helpers/domain_helpers'
 
 RSpec.configure do |config|
   config.include Features::SessionHelpers, type: :feature
   config.include Features::FormHelpers, type: :feature
+  config.include Features::DomainHelpers, type: :feature
 end

--- a/spec/support/helpers/domain_helpers.rb
+++ b/spec/support/helpers/domain_helpers.rb
@@ -1,0 +1,12 @@
+module Features
+  module DomainHelpers
+    def with_domain(host)
+      original_host = Capybara.app_host
+      Capybara.app_host = "http://#{host}"
+      yield
+    ensure
+      Capybara.app_host = original_host
+    end
+  end
+end
+

--- a/spec/support/helpers/session_helpers.rb
+++ b/spec/support/helpers/session_helpers.rb
@@ -21,6 +21,5 @@ module Features
       fill_in 'user_email', with: email
       click_button 'Send me reset password instructions'
     end
-
   end
 end


### PR DESCRIPTION

Reason for Change
=================
Recently while watching [this GoRails video on Domain and Subdomain Constraints](https://gorails.com/episodes/domain-subdomain-routing-constraints-in-rails?autoplay=1) I noticed that it was recommended to not do database requests in your routes constraints since it means that every request will need to make the request. 

It occurred to me that we could avoid the requests entirely by instead matching against the hosts for the events side of cfp-app. It means the environment variable needs to be set for most of cfp app to be accessible but that should not change much once it is done. 

Changes
=======
- Switches logic to match on non event host domain set in ENV variable
  rather than website domains stored in DB
- Moves config/initializers/domain_constraint.rb to app/constraints folder
- Set Rails configuration events_hosts value from EVENTS_HOSTS env
  variable with fallback defaults for non production environments
- Uses lvh.me as domain to more accurately test domain constraint logic
  in feature specs
