### PR TITLE
Fixes error when accessing schedule page on a custom domain

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -4,7 +4,7 @@ class ProgramsController < ApplicationController
   after_action :set_cache_headers, only: :show
 
   def show
-    @program_sessions = current_website.event.program_sessions.live
+    @program_sessions = current_website.program_sessions.live
     render layout: "themes/#{current_website.theme}"
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,13 +1,12 @@
 class ScheduleController < ApplicationController
   include WebsiteScheduleHelper
-  before_action :require_event
-
   after_action :set_cache_headers, only: :show
 
   decorates_assigned :schedule, with: Staff::TimeSlotDecorator
 
   def show
-    @schedule = current_event.time_slots.grid_order.includes(:room, program_session: { proposal: {speakers: :user}})
+    @schedule = current_website.time_slots.grid_order
+      .includes(:room, program_session: { proposal: {speakers: :user}})
     render layout: "themes/#{current_website.theme}"
   end
 end

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -4,7 +4,7 @@ class SponsorsController < ApplicationController
   after_action :set_cache_headers, only: :show
 
   def show
-    @sponsors_by_tier = current_website.event.sponsors.published.order_by_tier.group_by(&:tier)
+    @sponsors_by_tier = current_website.sponsors.published.order_by_tier.group_by(&:tier)
     render layout: "themes/#{current_website.theme}"
   end
 end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -2,6 +2,9 @@ class Website < ApplicationRecord
   enum caching: { off: 'off', automatic: 'automatic', manual: 'manual' }, _prefix: true
 
   belongs_to :event
+  has_many :time_slots, through: :event
+  has_many :sponsors, through: :event
+  has_many :program_sessions, through: :event
   has_many :pages, dependent: :destroy
   has_many :fonts, class_name: 'Website::Font', dependent: :destroy
   has_many :contents, class_name: 'Website::Content', dependent: :destroy

--- a/spec/features/website/schedule_spec.rb
+++ b/spec/features/website/schedule_spec.rb
@@ -88,6 +88,12 @@ feature "dynamic website schedule page" do
     expect(page).to have_content(time_slot.title)
   end
 
+  scenario 'Public views schedule page on custom domain' do
+    website.update(domains: 'www.example.com')
+    visit schedule_path
+    expect(current_path).to eq('/schedule')
+  end
+
   context "schedule page loads on the correct conference day" do
     it "displays the first event day before the conference start" do
       travel_to(event.start_date - 1.day) do


### PR DESCRIPTION
Reason for Change
=================
While working on custom domains I discovered that the schedule page is not accessible to the public from a custom domain url. This is easily masked when working from the backend because the current_event gets set that way. However, the constrained domain routes don't really require the event and instead are best accessed through the current_website which holds the logic for determining which event should be accessed from a custom domain. 

You can actually see the problem right now if you try going to https://rubyconf.org/schedule and it redirects you to https://rubyconf.org/events.

Changes
=======
- removes call to current_event and require_event which results in a
  redirect to root /events page when using a custom domain
- adds regression integration spec for bugfix
- skips calls to event when accessing time_slots, program_sessions and
  sponsors in controllers by using a has_many :through instead for
ease and consistency