### PR TITLE
Add hyperlink button to WYSIWYG toolbar

### DIFF
--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
       toolbar: 'undo redo | formatselect | ' +
       ' bold italic backcolor | alignleft aligncenter ' +
       ' alignright alignjustify | bullist numlist outdent indent | ' +
-      ' removeformat | image code | help',
+      ' removeformat | image link code | help',
       valid_elements: '*[*]',
       forced_root_block : '',
       images_upload_url: '/image_uploads',

--- a/spec/features/website/page_management_spec.rb
+++ b/spec/features/website/page_management_spec.rb
@@ -192,4 +192,26 @@ feature "Website Page Management" do
     expected_content = indented_html.gsub(initial_text, "#{initial_text}#{added_text}")
     expect(Page.last.unpublished_body).to eq(expected_content)
   end
+
+  scenario "Organizer can add a hyperlink from WYSIWYG editor", js: true do
+    login_as(organizer)
+    home_page = create(:page)
+    url = "http://example.com/resource/1"
+
+    visit edit_event_staff_page_path(event, home_page)
+    click_on('WYSIWYG')
+    click_on('More...')
+    click_on('Insert/edit link')
+
+    fill_in("URL", with: url)
+    within('.tox-dialog__footer') { click_on("Save") }
+    click_on("Save")
+
+    accept_confirm { click_on('Publish') }
+    click_on("View")
+
+    expect(page).to have_content(url)
+    click_on(url)
+    expect(page).to have_current_path(url, url: true)
+  end
 end


### PR DESCRIPTION
🟢 - Ready for review
# Reason for change
As a website page editor I should be able to easily add a hyperlink while using the WYSIWYG text editor

## Changes
Update configuration of the tinyMCE WYSIWYG toolbar to display a hyperlink button. 
Wrote a test to verify that the link button works, and that the when viewing the page the link behaves as expected. 