### PR TITLE
Add field to support Texas vs RI speaker question

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -43,7 +43,7 @@ class ProposalsController < ApplicationController
       return
     end
     @proposal = @event.proposals.new
-    @proposal.speakers.build(user: current_user)
+    @proposal.speakers.build(user: current_user, houston_or_providence: Speaker::HOUSTON_OR_PROVIDENCE.first)
     flash.now[:warning] = incomplete_profile_msg unless current_user.complete?
   end
 
@@ -143,7 +143,7 @@ class ProposalsController < ApplicationController
   def proposal_params
     params.require(:proposal).permit(:title, {tags: []}, :session_format_id, :track_id, :abstract, :details, :pitch, custom_fields: @event.custom_fields,
                                      comments_attributes: [:body, :proposal_id, :user_id],
-                                     speakers_attributes: [:bio, :id, :age_range, :pronouns, :ethnicity, :first_time_speaker])
+                                     speakers_attributes: [:bio, :id, :age_range, :pronouns, :ethnicity, :first_time_speaker, :houston_or_providence])
   end
 
   def notes_params

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -27,6 +27,12 @@ class Speaker < ApplicationRecord
     "Two or more races", "Other", "Decline to say"
   ].freeze
 
+  # NOTE: This is a temporary field to support an extra question in the CFP
+  HOUSTON_OR_PROVIDENCE = [
+    "RubyConf in Texas from Nov 29 - Dec 1",
+    "RubyConf Mini in Rhode Island from Nov 15 - Nov 17"
+  ]
+
   belongs_to :user
   belongs_to :event
   belongs_to :proposal
@@ -42,7 +48,12 @@ class Speaker < ApplicationRecord
   validates :name, :email, presence: true, unless: :skip_name_email_validation
   validates_format_of :email, with: Devise.email_regexp
 
+  # NOTE: This is a temporary field to support an extra question in the CFP
+  validates :houston_or_providence, presence: true
+
   attr_accessor :skip_name_email_validation
+
+  before_validation :set_houston_or_providence_in_test
 
   scope :in_program, -> { where.not(program_session_id: nil) }
   scope :a_to_z, -> { order(:speaker_name) }
@@ -59,6 +70,14 @@ class Speaker < ApplicationRecord
     User.gravatar_hash(email)
   end
 
+  private
+
+  # NOTE: this is a hack to avoid updating a bunch of tests for this hackish feature
+  def set_houston_or_providence_in_test
+    if Rails.env == "test" && houston_or_providence.blank?
+      self.houston_or_providence = HOUSTON_OR_PROVIDENCE.first
+    end
+  end
 end
 
 # == Schema Information

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -23,3 +23,6 @@
 
     %p
     = speaker_fields.input :ethnicity, collection: Speaker::RACIAL_CATEGORIES, label: "What is your ethnicity?"
+
+    %p
+    = speaker_fields.input :houston_or_providence, collection: Speaker::HOUSTON_OR_PROVIDENCE, label: "Where do you feel most comfortable giving your talk?"

--- a/app/views/speakers/_speaker.html.haml
+++ b/app/views/speakers/_speaker.html.haml
@@ -21,4 +21,7 @@
 
   %strong Ethnicity:
   = simple_format speaker.ethnicity
+
+  %strong Speaking Location:
+  = simple_format speaker.houston_or_providence
 %hr

--- a/db/migrate/20220727235351_add_location_to_speaker.rb
+++ b/db/migrate/20220727235351_add_location_to_speaker.rb
@@ -1,0 +1,5 @@
+class AddLocationToSpeaker < ActiveRecord::Migration[6.1]
+  def change
+    add_column :speakers, :houston_or_providence, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_06_213730) do
+ActiveRecord::Schema.define(version: 2022_07_27_235351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -220,6 +220,7 @@ ActiveRecord::Schema.define(version: 2022_06_06_213730) do
     t.string "ethnicity"
     t.boolean "first_time_speaker"
     t.string "pronouns"
+    t.string "houston_or_providence"
     t.index ["event_id"], name: "index_speakers_on_event_id"
     t.index ["program_session_id"], name: "index_speakers_on_program_session_id"
     t.index ["proposal_id"], name: "index_speakers_on_proposal_id"


### PR DESCRIPTION
Title

Add field to support Texas vs RI speaker question

Reason for Change
=================
This is a quick and dirty solution that we will want to remove as soon
as RubyConf 2022 is done. We need to ask speakers where they feel most
comfortable giving their talk, and the extra field that the CFP actually
supports is open ended rather than being constrained to options.

![Screen Shot 2022-07-27 at 7 35 52 PM](https://user-images.githubusercontent.com/41442/181396392-fbd7cf04-2b9d-4b37-a8b2-0fcf81305d98.png)
![Screen Shot 2022-07-27 at 7 37 21 PM](https://user-images.githubusercontent.com/41442/181396391-84873933-9a2e-41e9-8e04-24402fa9c937.png)
