### PR TITLE
Add options to indicate preference of Houston vs Mini, or only one

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The CFP App does not provide a public facing website for your conference, though
 
 ### Prerequisite Requirements
 
-* Ruby 3.0.4 (set in `.ruby-version`)
+* Ruby 3.1.2 (set in `.ruby-version`)
 * Bundler (was installed with 2.3.11)
 * PostgreSQL 14.1
 * Google Chrome browser must be installed to run tests

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -147,11 +147,18 @@ class ProposalsController < ApplicationController
   def hack_location_taggings
     speaker = @proposal.speakers.first
     speaker.proposals.where(event: @proposal.event).each do |p|
-      p.taggings.where(internal: true, tag: %w(providence houston)).destroy_all
-      if speaker.houston_or_providence =~ /texas/i
+      p.taggings.where(
+        internal: true,
+        tag: ["providence", "houston", "providence pref", "houston pref"]
+      ).destroy_all
+      if speaker.houston_or_providence =~ /Only RubyConf in Texas/
         p.taggings.create(tag: "houston", internal: true)
-      else
+      elsif speaker.houston_or_providence =~ /Only RubyConf Mini in Rhode Island/
         p.taggings.create(tag: "providence", internal: true)
+      elsif speaker.houston_or_providence =~ /Prefer RubyConf in Texas/
+        p.taggings.create(tag: "houston pref", internal: true)
+      else
+        p.taggings.create(tag: "providence pref", internal: true)
       end
     end
   end

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -29,8 +29,10 @@ class Speaker < ApplicationRecord
 
   # NOTE: This is a temporary field to support an extra question in the CFP
   HOUSTON_OR_PROVIDENCE = [
-    "RubyConf in Texas from Nov 29 - Dec 1",
-    "RubyConf Mini in Rhode Island from Nov 15 - Nov 17"
+    "Only RubyConf in Texas from Nov 29 - Dec 1",
+    "Only RubyConf Mini in Rhode Island from Nov 15 - Nov 17",
+    "Prefer RubyConf in Texas from Nov 29 - Dec 1, open to RubyConf Mini in Rhode Island from Nov 15 - Nov 17",
+    "Prefer RubyConf Mini in Rhode Island from Nov 15 - Nov 17, open to RubyConf in Texas from Nov 29 - Dec 1"
   ]
 
   belongs_to :user


### PR DESCRIPTION
Add options to indicate preference of Houston vs Mini, or only one

Reason for Change
=================
* We want to add options to indicate preferences, or only speaking at a specific conference

Changes
=======
* Add two more options, and two more tags

Here are screenshots of the change:

The first image shows the review view of proposals for all four types, and also one proposal for Houston created pre change (tag stays Houston):

<img width="1510" alt="Screen Shot 2022-08-09 at 8 34 38 PM" src="https://user-images.githubusercontent.com/1988560/183785463-1858de5b-27de-43f3-bdbc-d88cfa6b593b.png">

The second image shows the author view of the dropdown when submitting a CFP:

<img width="1162" alt="Screen Shot 2022-08-09 at 5 50 22 PM" src="https://user-images.githubusercontent.com/1988560/183785464-e8b9dbac-470a-4921-a6a4-9fea09ba965d.png">

