### PR TITLE
Add diamond tier to sponsor options

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -10,7 +10,7 @@ class Sponsor < ApplicationRecord
 
   validates_presence_of :primary_logo, :name, :tier, :url, :description
 
-  TIERS = ['platinum', 'gold', 'silver', 'bronze', 'other', 'supporter']
+  TIERS = ['diamond', 'platinum', 'gold', 'silver', 'bronze', 'other', 'supporter']
 
   scope :published, -> { where(published: true) }
   scope :with_footer_image, -> { joins(:footer_logo_attachment) }

--- a/spec/features/staff/sponsor_spec.rb
+++ b/spec/features/staff/sponsor_spec.rb
@@ -60,7 +60,7 @@ feature 'Event Sponsors' do
       Sponsor::TIERS.each { |tier| create(:sponsor, tier: tier) }
       visit event_staff_sponsors_path(event)
 
-      expect(page).to have_content(/platinum.*gold.*silver.*bronze.*other.*supporter/)
+      expect(page).to have_content(/diamond.*platinum.*gold.*silver.*bronze.*other.*supporter/)
     end
   end
 end


### PR DESCRIPTION
## Background

RailsConf doesn't have a Diamond sponsorship tier, but RubyConf does.

We've already sold one of these and need to add it to the website.


## Changes

Adding `diamond` to `Sponsor::TIERS`