### PR TITLE
Flex schedule sub navigation to column on smaller screens

### DIFF
--- a/app/assets/stylesheets/themes/default/schedule.scss
+++ b/app/assets/stylesheets/themes/default/schedule.scss
@@ -345,3 +345,16 @@
       }
     }
   }
+
+  @media screen and (max-width: 700px) and (orientation: portrait),
+  (max-width: 523px) and (orientation: landscape) {
+    .schedule-page-wrapper {
+      nav.sub-nav {
+        ul {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+        }
+      }
+    }
+  }


### PR DESCRIPTION
🟢 - Ready for Review
**Flex schedule sub navigation to column on smaller screens**

Reason for Change
=================
As a user, when viewing the schedule page on a smaller screen, the schedule sub navigation shouldn't run off the screen. 

Changes
=======
Added a slightly smaller breakpoint, to the schedule CSS. 
Breakpoint adds a rule to display the Schedule Sub nav as a column on smaller screens. 

Who doesn't love a preview 
=====================
![Screen Recording 2022-11-18 at 3 04 40 PM](https://user-images.githubusercontent.com/71521423/202811152-c789557a-75c8-430b-9098-790cab0fe532.gif)

