### PR TITLE
Hot fix for media urls set to empty strings

### DIFF
--- a/app/views/programs/_detail.html.haml
+++ b/app/views/programs/_detail.html.haml
@@ -14,10 +14,10 @@
   .program-session-about
     %span About
     = program_session.abstract.html_safe
-    - if program_session.video_url
+    - if program_session.video_url.present?
       %a{ :href => "#{program_session.video_url}", :title => "Session Video", :target => "_blank" }
         Video
-    - if program_session.slides_url
+    - if program_session.slides_url.present?
       %a{ :href => "#{program_session.slides_url}", :title => "Session Slides", :target => "_blank" }
         Slides
 


### PR DESCRIPTION
* Need to double check if the media url is not an empty string
* Understanding the difference between nil and empty
* Don't show link tags if media urls have been set and then removed