### PR TITLE
proposals.proposal_data may include serialized AC::Parameters as well

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,6 @@ module CFPApp
 
     config.active_job.queue_adapter = :sidekiq
     config.active_record.yaml_column_permitted_classes =
-      [Symbol, Hash, Array, ActiveSupport::HashWithIndifferentAccess]
+      [Symbol, Hash, Array, ActiveSupport::HashWithIndifferentAccess, ActionController::Parameters]
   end
 end


### PR DESCRIPTION
because CFP App 1.0 used to store proposals.proposal_data as a serialized AC::Parameters.

This follows up d70de792294b035b205ebadcc8ff0b5922711e75 and fixes
`Psych::DisallowedClass: Tried to load unspecified class: ActionController::Parameters` error that occurs when trying to show proposals that are posted on CFP App Version 1.

I know that Ruby Central folks may have never seen this error since you gave up migrating the V1 data to V2 and just abandoned them, but for those who somehow migrated the old data to V2 like we did for our conference RubyKaigi, I chose to upstream this patch instead of just updating our `proposal_data` in our DB to be normal Hash objects.