### PR TITLE
Avoid using hashrocket for a kwarg in a migration file

### DIFF
--- a/db/migrate/20200223215131_create_versions.rb
+++ b/db/migrate/20200223215131_create_versions.rb
@@ -10,7 +10,7 @@ class CreateVersions < ActiveRecord::Migration[5.2]
 
   def change
     create_table :versions do |t|
-      t.string   :item_type, {:null=>false}
+      t.string   :item_type, null: false
       t.integer  :item_id,   null: false, limit: 8
       t.string   :event,     null: false
       t.string   :whodunnit


### PR DESCRIPTION
This patch manually edits a broken migration file introduced via a9916717f2e297e4e4dd7eb57ea3865f2e03a8a0.

Since the hashrocket here will be treated as a Hash object literal rather than a kwarg under recent versions of Ruby, which will end up with creating broken schema.rb with the following diff via `db:migrate`.
```diff
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
```