### PR TITLE
Let ProgramSession#track be optional

### DIFF
--- a/app/models/program_session.rb
+++ b/app/models/program_session.rb
@@ -37,7 +37,7 @@ class ProgramSession < ApplicationRecord
 
   belongs_to :event
   belongs_to :proposal
-  belongs_to :track
+  belongs_to :track, optional: true
   belongs_to :session_format
   has_one :time_slot, dependent: :nullify
   has_many :speakers, -> { order(:created_at)}


### PR DESCRIPTION
We don't have a concept or an implementation of "tracks" in a small conference that we run called RubyKaigi. So we get stuck on a validation here every time when we try to create a ProgramSession, and we have to workaround by registering a dummy Track record.
I suppose there should be other conferences like ours, so let me upstream our in-house patch that skips this validation.