### PR TITLE
Let Room name be unique within each event

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,7 +2,7 @@ class Room < ApplicationRecord
   belongs_to :event
   has_many :time_slots
 
-  validates :name, uniqueness: true, presence: true
+  validates :name, uniqueness: {scope: :event_id}, presence: true
   scope :by_grid_position, -> {where.not(grid_position: nil).order(:grid_position)}
   scope :grid_order, -> { order(:grid_position) }
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -2,11 +2,15 @@ require 'rails_helper'
 
 describe Room do
   describe "validations" do
-    it "requires that names are unique" do
-      room = create(:room, name: 'name')
-      room2 = build(:room, name: room.name)
-
+    it "requires that names are unique within an event" do
+      event1 = create(:event)
+      room = create(:room, event: event1, name: 'name')
+      room2 = build(:room, event: event1, name: room.name)
       expect(room2).to be_invalid
+
+      event2 = create(:event)
+      room3 = build(:room, event: event2, name: room.name)
+      expect(room3).to be_valid
     end
   end
 end


### PR DESCRIPTION
Currently, rooms.name is constrained to be unique within the whole database, but in the real world, conference venues tend to name their room very similarly, for instance, "Room A, Room B, Room C..." or "101, 102, 103...". So we have to somehow workaround on cfp-app by prefixing or suffixing year or something.

I don't think there's any use case that requires the Room names to be unique across the years, thus this attribute doesn't have to be DB unique but should better be unique per event.