### PR TITLE
Use newer Browser-Tools Orb on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
     jobs:
       - build_and_test
 orbs:
-  browser-tools: circleci/browser-tools@1.1
+  browser-tools: circleci/browser-tools@1.4
 jobs:
   build_and_test:
     working_directory: ~/cfp_app


### PR DESCRIPTION
CircleCI seems to be running again now, https://app.circleci.com/pipelines/github/rubycentral/cfp-app
but currently it's failing to install ChromeDriver. https://app.circleci.com/pipelines/github/rubycentral/cfp-app/449/workflows/7f8efd7f-e9b1-4a67-98a0-d1a0684b1968/jobs/454

Let's update Browser-Tools version and see if it works.