### PR TITLE
Prefer Arel based AR DSL over SQL string in scopes

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -44,7 +44,7 @@ class Proposal < ApplicationRecord
   scope :accepted, -> { where(state: ACCEPTED) }
   scope :waitlisted, -> { where(state: WAITLISTED) }
   scope :submitted, -> { where(state: SUBMITTED) }
-  scope :confirmed, -> { where('confirmed_at IS NOT NULL') }
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
 
   scope :soft_accepted, -> { where(state: SOFT_ACCEPTED) }
   scope :soft_waitlisted, -> { where(state: SOFT_WAITLISTED) }


### PR DESCRIPTION
Or this scope causes "PG::AmbiguousColumn: ERROR:  column reference "confirmed_at" is ambiguous" when joined with another table that has `confirmed_at` column.

Example
=================
Proposal.joins(speakers: :user).confirmed
 => ActiveRecord::StatementInvalid (PG::AmbiguousColumn: ERROR:  column reference "confirmed_at" is ambiguous)
