### PR TITLE
Fix skipped specs by wrong factory callbacks

### DIFF
--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -107,8 +107,7 @@ describe ProposalsController, type: :controller do
     end
 
     it "sends an in-app notification to reviewers" do
-      skip("Rating not recognized as a proposal.reviewer and I haven't figured out how to make FactoryBot happy")
-      create(:rating, proposal: proposal, user: create(:organizer))
+      create(:rating, proposal: proposal, user: create(:reviewer, event: event))
       expect {
         post :withdraw, params: {event_slug: event.slug, uuid: proposal.uuid}
       }.to change { Notification.count }.by(1)
@@ -157,7 +156,6 @@ describe ProposalsController, type: :controller do
     end
 
     it "sends a notifications to an organizer" do
-      skip("Rating not recognized as a proposal.reviewer and I haven't figured out how to make FactoryBot happy")
       proposal.update(title: 'orig_title', pitch: 'orig_pitch')
       organizer = create(:organizer, event: proposal.event)
       create(:rating, proposal: proposal, user: organizer)

--- a/spec/controllers/staff/grids/time_slots_controller_spec.rb
+++ b/spec/controllers/staff/grids/time_slots_controller_spec.rb
@@ -2,12 +2,11 @@ require 'rails_helper'
 
 describe Staff::Grids::TimeSlotsController, type: :controller do
   let(:event) { create(:event) }
-  let(:proposal) { create(:proposal_with_track) }
+  let(:proposal) { create(:proposal_with_track, event: event) }
   before { sign_in(create(:organizer, event: event)) }
 
   describe "PUT 'update'" do
     it "can update a time slot with ajax" do
-      skip "FactoryBot 😤"
       conf_time_slot = create(:time_slot, conference_day: 3, event: event)
       put :update, xhr: true, params: {id: conf_time_slot, event_slug: conf_time_slot.event,
           time_slot: { conference_day: 5 }}, format: :json
@@ -18,7 +17,6 @@ describe Staff::Grids::TimeSlotsController, type: :controller do
     end
 
     it "can set the program session" do
-      skip "FactoryBot 😤"
       program_session = create(:program_session, event: event, proposal: proposal, track: proposal.track)
       conf_time_slot = create(:time_slot, event: program_session.event)
       put :update, xhr: true, params: {id: conf_time_slot, event_slug: conf_time_slot.event,

--- a/spec/controllers/staff/proposals_controller_spec.rb
+++ b/spec/controllers/staff/proposals_controller_spec.rb
@@ -73,8 +73,7 @@ describe Staff::ProposalsController, type: :controller do
     end
 
     it "sends appropriate emails" do
-      skip "Record not found -- need to figure out the factory magic here"
-      proposal = create(:proposal_with_track, state: Proposal::State::SOFT_ACCEPTED)
+      proposal = create(:proposal_with_track, event: event, state: Proposal::State::SOFT_ACCEPTED)
       mail = double(:mail, deliver_now: nil)
       expect(Staff::ProposalMailer).to receive('send_email').and_return(mail)
       post :finalize, params: {event_slug: event, proposal_uuid: proposal.uuid}

--- a/spec/controllers/staff/rooms_controller_spec.rb
+++ b/spec/controllers/staff/rooms_controller_spec.rb
@@ -6,7 +6,6 @@ describe Staff::RoomsController, type: :controller do
 
   describe "DELETE 'destroy'" do
     it "destroys the room with ajax" do
-      skip "FactoryBot 😤"
       room = create(:room, event: event)
       expect {
         delete :destroy, xhr: true, params: {id: room, event_slug: event}

--- a/spec/controllers/staff/time_slots_controller_spec.rb
+++ b/spec/controllers/staff/time_slots_controller_spec.rb
@@ -6,7 +6,6 @@ describe Staff::TimeSlotsController, type: :controller do
 
   describe "DELETE 'destroy'" do
     it "destroys the time slot" do
-      skip "FactoryBot 😤"
       conf_time_slot = create(:time_slot, event: event)
       expect {
         delete :destroy, xhr: true, params: {id: conf_time_slot, event_slug: conf_time_slot.event}
@@ -16,7 +15,6 @@ describe Staff::TimeSlotsController, type: :controller do
 
   describe "PUT 'update'" do
     it "can update a time slot with ajax" do
-      skip "FactoryBot 😤"
       conf_time_slot = create(:time_slot, conference_day: 3, event: event)
       put :update, xhr: true, params: {id: conf_time_slot, event_slug: conf_time_slot.event,
           time_slot: { conference_day: 5 }}
@@ -25,7 +23,6 @@ describe Staff::TimeSlotsController, type: :controller do
     end
 
     it "can set the program session" do
-      skip "FactoryBot 😤"
       program_session = create(:program_session, event: event)
       conf_time_slot = create(:time_slot, event: program_session.event)
       put :update, xhr: true, params: {id: conf_time_slot, event_slug: conf_time_slot.event,

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
     trait :with_reviewer_public_comment do
       after(:create) do |proposal|
-        reviewer = FactoryBot.create(:user, :reviewer)
+        reviewer = FactoryBot.create(:reviewer, event: proposal.event)
         FactoryBot.create(:comment, proposal: proposal, type: "PublicComment", user: reviewer, body: "Reviewer comment" )
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
       after(:create) do |user, evaluator|
         teammate = user.organizer_teammates.first
         teammate.event = evaluator.event
-        teammate.event.save
+        teammate.save
       end
     end
 
@@ -60,7 +60,7 @@ FactoryBot.define do
       after(:create) do |user, evaluator|
         teammate = user.reviewer_teammates.first
         teammate.event = evaluator.event
-        teammate.event.save
+        teammate.save
       end
     end
 

--- a/spec/features/staff/sponsor_spec.rb
+++ b/spec/features/staff/sponsor_spec.rb
@@ -50,7 +50,6 @@ feature 'Event Sponsors' do
     end
 
     it 'can delete an event sponsor', js: true do
-      skip "FactoryBot 😤"
       sponsor = create(:sponsor, event: event)
       visit edit_event_staff_sponsor_path(event, sponsor)
 
@@ -60,7 +59,6 @@ feature 'Event Sponsors' do
     end
 
     it 'sponsons are listed in tier order on the index page' do
-      skip "FactoryBot 😤"
       Sponsor::TIERS.each { |tier| create(:sponsor, tier: tier) }
       visit event_staff_sponsors_path(event)
 

--- a/spec/features/website/configuration_spec.rb
+++ b/spec/features/website/configuration_spec.rb
@@ -6,7 +6,6 @@ feature "Website Configuration" do
   let(:organizer) { create(:organizer, event: event) }
 
   scenario "Organizer creates a new website for event" do
-    skip "FactoryBot 😤"
     login_as(organizer)
 
     visit event_path(event)
@@ -18,7 +17,6 @@ feature "Website Configuration" do
   end
 
   scenario "Organizer configures domain for an existing website for event", :js do
-    skip "FactoryBot 😤"
     website = create(:website, event: event)
     home_page = create(:page, website: website)
 
@@ -50,7 +48,6 @@ feature "Website Configuration" do
   end
 
   scenario "Organizer fails to add font file correctly", :js do
-    skip "FactoryBot 😤"
     website = create(:website, event: event)
 
     login_as(organizer)

--- a/spec/features/website/program_spec.rb
+++ b/spec/features/website/program_spec.rb
@@ -6,17 +6,15 @@ feature "website program page" do
   let!(:website) { create(:website, event: event) }
 
   scenario "A program session is on the program session page", js: true do
-    skip "FactoryBot 😤"
-    regular_session = create(:regular_session)
+    regular_session = create(:regular_session, event: event)
 
     visit program_path(event)
     expect(page).to have_content(regular_session.title)
   end
 
   scenario "the website program page displays sessions under the correct session format", js: true do
-    skip "FactoryBot 😤"
-    regular_session = create(:regular_session)
-    workshop = create(:workshop_session)
+    regular_session = create(:regular_session, event: event)
+    workshop = create(:workshop_session, event: event)
     visit program_path(event)
 
     expect(page).to have_content(regular_session.title)
@@ -27,9 +25,8 @@ feature "website program page" do
   end
 
   scenario "the event website program page reflects updates to program sessions", js: true do
-    skip "FactoryBot 😤"
     login_as(organizer)
-    regular_session = create(:regular_session)
+    regular_session = create(:regular_session, event: event)
 
     visit program_path(event)
     expect(page).to have_content(regular_session.title)
@@ -44,9 +41,8 @@ feature "website program page" do
   end
 
   scenario "the event website page stops displaying deleted program sessions", js: true do
-    skip "FactoryBot 😤"
     login_as(organizer)
-    regular_session = create(:regular_session)
+    regular_session = create(:regular_session, event: event)
 
     visit program_path(event)
     expect(page).to have_content(regular_session.title)

--- a/spec/features/website/schedule_spec.rb
+++ b/spec/features/website/schedule_spec.rb
@@ -41,7 +41,6 @@ feature "dynamic website schedule page" do
   end
 
   scenario "the event website schedule page displays time slots that have program sessions", js: true do
-    skip "FactoryBot 😤"
     time_slot = create(:with_workshop_session, event: event)
 
     visit schedule_path(event)
@@ -49,7 +48,6 @@ feature "dynamic website schedule page" do
   end
 
   scenario "the event website schedule page displays updates to time slots that have program sessions", js: true do
-    skip "FactoryBot 😤"
     time_slot = create(:with_workshop_session, event: event)
 
     time_slot.update(start_time: (time_slot.start_time - 1.hour))

--- a/spec/mailers/comment_notification_mailer_spec.rb
+++ b/spec/mailers/comment_notification_mailer_spec.rb
@@ -34,7 +34,7 @@ describe CommentNotificationMailer do
 
   describe "reviewer_notification" do
     let(:proposal) { create(:proposal, :with_reviewer_public_comment) }
-    let(:reviewer) { create(:user, :reviewer) }
+    let(:reviewer) { create(:reviewer, event: proposal.event) }
     let(:comment) { create(:comment, proposal: proposal, type: "PublicComment", user: reviewer, body: "Reviewer comment as a Reviewer on Proposal") }
     let(:speaker) { create(:speaker) }
     let(:speaker_comment) { create(:comment, user: speaker.user, proposal: proposal) }
@@ -48,19 +48,16 @@ describe CommentNotificationMailer do
       end
 
       it "emails reviewers when speaker comments" do
-        skip "FactoryBot 😤"
         expect(proposal.reviewers.count).to eq(2)
         expect(mail.to.count).to eq(2)
         expect(mail.to).to match_array([proposal.reviewers.first.email, reviewer.email])
       end
 
       it "has proper subject" do
-        skip "FactoryBot 😤"
         expect(mail.subject).to eq("#{proposal.event.name} CFP: New comment on '#{proposal.title}'")
       end
 
       it "has proper body content" do
-        skip "FactoryBot 😤"
         expect(mail.body.encoded).to match(proposal.event.name)
         expect(mail.body.encoded).to match(proposal.title)
         expect(mail.body.encoded).to match("A comment has been left on the proposal '#{proposal.title}' for #{proposal.event.name}:")

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -334,12 +334,11 @@ describe Proposal do
 
   describe "#update" do
     let(:proposal) { create(:proposal_with_track, title: 't') }
-    let(:organizer) { create(:user, :organizer) }
+    let(:organizer) { create(:organizer, event: proposal.event) }
 
     describe ".last_change" do
       describe "when role organizer" do
         it "is cleared" do
-          skip "FactoryBot 😤"
           proposal.update(title: 'Organizer Edited Title', updating_user: organizer)
           expect(proposal.last_change).to be_nil
         end
@@ -410,11 +409,10 @@ describe Proposal do
 
   describe "#reviewers" do
     let!(:proposal) { create(:proposal_with_track) }
-    let!(:reviewer) { create(:user, :reviewer) }
+    let!(:reviewer) { create(:reviewer, event: proposal.event) }
     let!(:organizer) { create(:organizer, event: proposal.event) }
 
     it "can return the list of reviewers" do
-      skip "FactoryBot 😤"
       create(:rating, user: reviewer, proposal: proposal)
       proposal.public_comments.create(attributes_for(:comment, user: organizer))
 
@@ -426,7 +424,6 @@ describe Proposal do
     end
 
     it "does not list a reviewer more than once" do
-      skip "FactoryBot 😤"
       create(:rating, user: reviewer, proposal: proposal)
       proposal.public_comments.create(attributes_for(:comment, user: reviewer))
 
@@ -437,34 +434,32 @@ describe Proposal do
   describe 'emailable_reviewers' do
     let!(:proposal) { create(:proposal_with_track) }
     let!(:no_email_reviewer) do
-      reviewer = create(:user, :reviewer)
+      reviewer = create(:reviewer, event: proposal.event)
       reviewer.teammates.first.update_attribute(:notification_preference, Teammate::IN_APP_ONLY)
       create(:rating, user: reviewer, proposal: proposal)
       reviewer
     end
     let!(:mentions_only_reviewer) do
-      reviewer = create(:user, :reviewer)
+      reviewer = create(:reviewer, event: proposal.event)
       reviewer.teammates.first.update_attribute(:notification_preference, Teammate::MENTIONS)
       create(:rating, user: reviewer, proposal: proposal)
       reviewer
     end
     let!(:reviewer) do
-      reviewer = create(:user, :reviewer)
+      reviewer = create(:reviewer, event: proposal.event)
       create(:rating, user: reviewer, proposal: proposal)
       reviewer
     end
 
     it 'returns only reviewers with all emails turned on' do
-      skip "FactoryBot 😤"
       expect(proposal.emailable_reviewers).to match_array([ reviewer ])
     end
   end
 
   describe "#speaker_update_and_notify" do
     it "sends notification to all reviewers" do
-      skip "FactoryBot 😤"
       proposal = create(:proposal_with_track, title: 'orig_title', pitch: 'orig_pitch')
-      reviewer = create(:user, :reviewer)
+      reviewer = create(:reviewer, event: proposal.event)
       organizer = create(:organizer, event: proposal.event)
 
       create(:rating, user: reviewer, proposal: proposal)
@@ -481,9 +476,8 @@ describe Proposal do
     end
 
     it "uses the old title in the notification message" do
-      skip "FactoryBot 😤"
       proposal = create(:proposal_with_track, title: 'orig_title')
-      reviewer = create(:user, :reviewer)
+      reviewer = create(:reviewer, event: proposal.event)
       create(:rating, user: reviewer, proposal: proposal)
 
       proposal.speaker_update_and_notify(title: 'new_title')
@@ -516,7 +510,6 @@ describe Proposal do
     end
 
     it "sends a notification to reviewers" do
-      skip "FactoryBot 😤"
       proposal = create(:proposal_with_track, :with_reviewer_public_comment,
                         state: SUBMITTED)
       expect {

--- a/spec/models/public_comment_spec.rb
+++ b/spec/models/public_comment_spec.rb
@@ -9,7 +9,6 @@ describe PublicComment do
         let(:proposal) { create(:proposal_with_track, :with_organizer_public_comment, :with_speaker) }
         let(:organizer) { Teammate.for_event(proposal.event).organizer.first.user }
         it "creates a notification" do
-          skip "FactoryBot 😤"
           expect {
             proposal.public_comments.create(attributes_for(:comment, user: speaker))
           }.to change {
@@ -18,7 +17,6 @@ describe PublicComment do
         end
 
         it "does not show the name of the speaker" do
-          skip "FactoryBot 😤"
           proposal.public_comments.create(attributes_for(:comment, user: speaker))
           expect(organizer.reload.notifications.last.message).to_not match(speaker.name)
         end
@@ -29,7 +27,6 @@ describe PublicComment do
         let(:reviewer) { Teammate.for_event(proposal.event).reviewer.first.user }
 
         it "creates a notification" do
-          skip "FactoryBot 😤"
           expect {
             proposal.public_comments.create(attributes_for(:comment, user: speaker))
           }.to change {
@@ -38,7 +35,6 @@ describe PublicComment do
         end
 
         it "does not show the name of the speaker" do
-          skip "FactoryBot 😤"
           proposal.public_comments.create(attributes_for(:comment, user: speaker))
           expect(reviewer.reload.notifications.last.message).to_not match(speaker.name)
         end
@@ -89,7 +85,6 @@ describe PublicComment do
 
       describe "for organizers who have rated the proposal" do
         it "creates a notification" do
-          skip "FactoryBot 😤"
           proposal = create(:proposal_with_track, :with_speaker)
           organizer = create(:organizer, event: proposal.event)
           create(:rating, proposal: proposal, user: organizer)
@@ -134,7 +129,7 @@ describe PublicComment do
   describe "#send_emails" do
     let!(:proposal) { create(:proposal_with_track) }
     let!(:speakers) { create_list(:speaker, 3, proposal: proposal) }
-    let!(:reviewer) { create(:user, :reviewer) }
+    let!(:reviewer) { create(:reviewer, event: proposal.event) }
     context "when reviewer creates a PublicComment" do
       it "should send notication to each speaker" do
         expect {
@@ -148,7 +143,6 @@ describe PublicComment do
     context 'Speaker create a PublicComment' do
       before { proposal.public_comments.create(attributes_for(:comment, user: reviewer)) }
       it 'should send notification to reviewer if speaker comments' do
-        skip "FactoryBot 😤"
         expect {
           proposal.public_comments.create(attributes_for(:comment, user: speakers.first.user))
         }.to change(ActionMailer::Base.deliveries, :count).by(1)

--- a/spec/models/teammate_spec.rb
+++ b/spec/models/teammate_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe Teammate do
   describe "validations" do
     let(:user) { create(:user, email: "teammate@event.com") }
+    let(:event) { create(:event) }
     it "requires names and emails to be unique per event" do
-      skip "FactoryBot 😤"
-      teammate1 = create(:teammate, role: "reviewer", email: user.email, mention_name: 'teammate', user: user)
-      teammate2 = build(:teammate, role: "reviewer", email: teammate1.email, mention_name: teammate1.mention_name, user: user)
+      teammate1 = create(:teammate, role: "reviewer", email: user.email, mention_name: 'teammate', user: user, event: event)
+      teammate2 = build(:teammate, role: "reviewer", email: teammate1.email, mention_name: teammate1.mention_name, user: user, event: event)
 
       expect(teammate2).to be_invalid
       expect(teammate2.errors.messages.keys).to include(:email, :mention_name)

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe PagePolicy do
     :promote?
   )  do
     it 'allows organizers for event' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(organizer))
     end
 

--- a/spec/policies/program_session_policy_spec.rb
+++ b/spec/policies/program_session_policy_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ProgramSessionPolicy do
-  let(:program_team) { create(:user, :program_team) }
-  let(:organizer) { create(:user, :organizer) }
-  let(:program_session) { create(:program_session_with_proposal) }
+  let(:event) { create(:event) }
+  let(:program_team) { create(:program_team, event: event) }
+  let(:organizer) { create(:organizer, event: event) }
+  let(:program_session) { create(:program_session_with_proposal, event: event) }
 
   subject { described_class }
 
@@ -17,19 +18,16 @@ RSpec.describe ProgramSessionPolicy do
     end
 
     it 'allows organizer users' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(organizer), program_session)
     end
   end
 
   permissions :show? do
     it 'allows program team users' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(program_team), program_session)
     end
 
     it 'allows organizer users' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(organizer), program_session)
     end
   end

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe ProposalPolicy do
   let(:reviewer) { create(:user, :reviewer) }
   let(:program_team) { create(:user, :program_team) }
-  let(:organizer) { create(:organizer) }
-  let(:speaker) { create(:speaker) }
+  let(:event) { create(:event) }
+  let(:organizer) { create(:organizer, event: event) }
+  let(:speaker) { create(:speaker, event: event) }
 
   subject { described_class }
 
@@ -36,7 +37,6 @@ RSpec.describe ProposalPolicy do
     end
 
     it 'allows organizer users' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(organizer), speaker)
     end
 

--- a/spec/policies/speaker_policy_spec.rb
+++ b/spec/policies/speaker_policy_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe SpeakerPolicy do
   let(:program_team) { create(:user, :program_team) }
-  let(:organizer) { create(:user, :organizer) }
-  let(:speaker) { create(:speaker) }
+  let(:event) { create(:event) }
+  let(:organizer) { create(:organizer, event: event) }
+  let(:speaker) { create(:speaker, event: event) }
 
   subject { described_class }
 
@@ -17,7 +18,6 @@ RSpec.describe SpeakerPolicy do
     end
 
     it 'allows organizer users' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(organizer), speaker)
     end
   end

--- a/spec/policies/website_policy_spec.rb
+++ b/spec/policies/website_policy_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe WebsitePolicy do
 
   permissions :show?, :new?, :create?, :edit?, :update?, :purge? do
     it 'allows organizers for event' do
-      skip "FactoryBot 😤"
       expect(subject).to permit(pundit_user(organizer))
     end
 

--- a/spec/support/shared_examples/a_proposal_page.rb
+++ b/spec/support/shared_examples/a_proposal_page.rb
@@ -14,7 +14,6 @@ shared_examples "a proposal page" do |path_method|
       end
 
       it "can leave a public comment" do
-        skip "FactoryBot 😤"
         form = find('#new_public_comment')
 
         form.fill_in 'public_comment_body', with: 'A new comment'
@@ -24,7 +23,6 @@ shared_examples "a proposal page" do |path_method|
       end
 
       it "can leave an internal comment" do
-        skip "FactoryBot 😤"
         form = find('#new_internal_comment')
 
         form.fill_in 'internal_comment_body', with: 'A new comment'
@@ -38,7 +36,6 @@ shared_examples "a proposal page" do |path_method|
       before { visit send(path_method, event, proposal) }
 
       it "can rate a proposal", js: true do
-        skip "FactoryBot 😤"
         within("#rating-form") do
           find("input[value='5']", visible: false).set(true)
         end


### PR DESCRIPTION
The factory callbacks defined `spec/factories/users.rb` are wrong. Fix it and re-enable skipped test cases that failed by the wrong factory callbacks.