### PR TITLE
"You must have ImageMagick or GraphicsMagick installed"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libvips postgresql-client libpq-dev
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libvips postgresql-client libpq-dev imagemagick
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Here's another attempt to fix "You must have ImageMagick or GraphicsMagick installed" error on CI... https://github.com/rubycentral/cfp-app/actions/runs/12268483070/job/34230381458#step:7:814
