### PR TITLE
Order admin events by archived and id desc

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -41,7 +41,7 @@ class Admin::EventsController < Admin::ApplicationController
   end
 
   def index
-    @events = Event.order("archived").all
+    @events = Event.order(:archived, id: :desc)
   end
 
 end


### PR DESCRIPTION
Currently, admin/events are ordered by id asc, which means old event comes first, but for organizations having many events (we at RubyKaigi have 17 events), it sometimes feels a bit hard to find the one we're currently focusing on. Instead, it'd be better if simply newest one always comes at the very top of the list.