### PR TITLE
Avoid uuid collision in specs

### DIFF
--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     factory :proposal_with_track do
       event
-      sequence(:title) { |i| "A fine proposal#{i}" }
+      sequence(:title) { |i| "A fine proposal with track#{i}" }
       abstract { Faker::Hacker.say_something_smart }
       details { Faker::Hipster.sentence }
       pitch { Faker::Superhero.name }


### PR DESCRIPTION
Having multiple sequences that generates same titles sometimes causes uuid collision in [Proposal#set_uuid](https://github.com/rubycentral/cfp-app/blob/5ccf7f51993e0fcce3f24d313e3b4dd7a8f7df96/app/models/proposal.rb#L301).

e.g. https://github.com/rubycentral/cfp-app/actions/runs/12991668229/job/36229725758