### PR TITLE
Perhaps we should `bundle e rails` over `bin/rails`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres@localhost:5432/cfp_app_test
-        run: bin/rails db:setup assets:precompile spec
+        run: bundle e rails db:setup assets:precompile spec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
so Rails can find bundled logger gem?

https://github.com/rubycentral/cfp-app/actions/runs/12996646226/job/36245863805?pr=443