### PR TITLE
Speaker factory needs an Event

### DIFF
--- a/spec/factories/program_sessions.rb
+++ b/spec/factories/program_sessions.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     event
 
     factory :program_session_with_proposal do
-      proposal { create(:proposal_with_track, state: Proposal::ACCEPTED) }
+      proposal { create(:proposal_with_track, state: Proposal::ACCEPTED, event: event) }
       track { proposal.track }
 
       trait :with_speaker do

--- a/spec/features/staff/organizer_manages_program_session_spec.rb
+++ b/spec/features/staff/organizer_manages_program_session_spec.rb
@@ -115,20 +115,19 @@ feature "Organizers can manage program sessions" do
   end
 
   scenario "organizer deleting program session deletes speaker if no proposals", js: true do
-    speaker = create(:speaker, event: program_session.event, program_session: program_session)
+    speaker = create(:speaker, event: event, program_session: program_session)
 
     visit edit_event_staff_program_session_path(event, program_session)
     page.accept_confirm { click_on "Delete Program Session" }
 
-    # expect(current_path).to eq(event_staff_program_sessions_path(event))
+    expect(current_path).to eq(event_staff_program_sessions_path(event))
     expect(page).not_to have_content(program_session.title)
     expect(event.speakers).not_to include(speaker)
   end
 
   scenario "organizer can delete program session without deleting speakers associated with a proposal", js: true do
-    skip "FactoryBot 😤"
-    program_session_two = create(:program_session_with_proposal)
-    speaker = create(:speaker, event: program_session_two.event, proposal: program_session_two.proposal, program_session: program_session_two)
+    program_session_two = create(:program_session_with_proposal, event: event)
+    speaker = create(:speaker, event: event, proposal: program_session_two.proposal, program_session: program_session_two)
 
     visit edit_event_staff_program_session_path(event, program_session_two)
     page.accept_confirm { click_on "Delete Program Session" }

--- a/spec/features/staff/speakers_spec.rb
+++ b/spec/features/staff/speakers_spec.rb
@@ -14,24 +14,19 @@ feature "Organizers can manage speakers for Program Sessions" do
   let!(:event_staff_teammate) { create(:teammate, :organizer, user: organizer_user, event: event) }
 
   let(:speaker_user_1) { create(:user) }
-  let!(:speaker_1) { create(:speaker, proposal: proposal_1,
-                                      user: speaker_user_1) }
+  let!(:speaker_1) { create(:speaker, event: event, proposal: proposal_1, user: speaker_user_1) }
 
   let(:speaker_user_2) { create(:user) }
-  let!(:speaker_2) { create(:speaker, proposal: proposal_2,
-                                      user: speaker_user_2) }
+  let!(:speaker_2) { create(:speaker, event: event, proposal: proposal_2, user: speaker_user_2) }
 
   let(:speaker_user_3) { create(:user) }
-  let!(:speaker_3) { create(:speaker, program_session: program_session_1,
-                                      user: speaker_user_3) }
+  let!(:speaker_3) { create(:speaker, event: event, program_session: program_session_1, user: speaker_user_3) }
 
   let(:speaker_user_4) { create(:user) }
-  let!(:speaker_4) { create(:speaker, program_session: program_session_1,
-                                      user: speaker_user_4) }
+  let!(:speaker_4) { create(:speaker, event: event, program_session: program_session_1, user: speaker_user_4) }
 
   let(:speaker_user_5) { create(:user) }
-  let!(:speaker_5) { create(:speaker, program_session: program_session_2,
-                                      user: speaker_user_5) }
+  let!(:speaker_5) { create(:speaker, event: event, program_session: program_session_2, user: speaker_user_5) }
 
   before :each do
     logout
@@ -41,7 +36,6 @@ feature "Organizers can manage speakers for Program Sessions" do
 
   context "An organizer" do
     it "Only sees speakers of program sessions" do
-      skip "FactoryBot 😤"
       expect(page).to have_content(speaker_3.name)
       expect(page).to have_content(speaker_3.email)
       # check for program session title linking to ?program session show page?
@@ -60,7 +54,6 @@ feature "Organizers can manage speakers for Program Sessions" do
     end
 
     it "Can edit a program sessions speaker" do
-      skip "FactoryBot 😤"
       row = find("tr#speaker-#{speaker_3.id}")
       old_name = speaker_3.name
       old_email = speaker_3.email
@@ -101,7 +94,6 @@ feature "Organizers can manage speakers for Program Sessions" do
     end
 
     it "Can't update a speaker with a bad email" do
-      skip "FactoryBot 😤"
       row = find("tr#speaker-#{speaker_3.id}")
       within row do
         click_on "Edit"


### PR DESCRIPTION
because Speaker.belongs_to :event.

This patch brings some pending specs back to life by fixing broken factories.