### PR TITLE
Use transactional fixtures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ end
 group :development, :test do
   gem 'amazing_print', require: false
   gem 'capybara', '~> 3.37'
-  gem 'database_cleaner', '~> 2.1'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'growl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,12 +150,6 @@ GEM
     country_select (10.0.0)
       countries (> 5.0, < 8.0)
     crass (1.0.6)
-    database_cleaner (2.1.0)
-      database_cleaner-active_record (>= 2, < 3)
-    database_cleaner-active_record (2.2.0)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
     date (3.4.1)
     debug_inspector (1.1.0)
     devise (4.8.1)
@@ -545,7 +539,6 @@ DEPENDENCIES
   chartkick
   coderay (~> 1.0)
   country_select (~> 10.0)
-  database_cleaner (~> 2.1)
   devise (~> 4.8)
   diffy
   dotenv-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,22 +36,13 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_base_class_for_anonymous_controllers = false
 
+  config.use_transactional_fixtures = true
+
   config.include FactoryBot::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers
 
-  # DB cleaning
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
   config.before(:each) do |example|
     init_mock_omniauth
-    DatabaseCleaner.strategy= example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
   end
 
   config.before(:all) do


### PR DESCRIPTION
Perhaps we don't need to rely on 3rd party database cleaning gem in favor of Rails' default transactional tests.