### PR TITLE
Show proposal diff for reviewers, not submitters

### DIFF
--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -22,14 +22,3 @@
       %div
       = value.capitalize
       %div
-
-- unless proposal.changeset_fields.blank?
-  %h2.fieldset-legend Proposal Diff...
-  - proposal.versions.each do |version|
-    #diff-view
-      - version.changeset.each do |k, (old, new)|
-        %h3.control-label= k.titleize
-        %div= diff old, new
-
-:css
-  = #{Diffy::CSS}

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -22,3 +22,14 @@
       %div
       = value.capitalize
       %div
+
+- unless proposal.changeset_fields.blank?
+  %h2.fieldset-legend Proposal Diff...
+  - proposal.versions.each do |version|
+    #diff-view
+      - version.changeset.each do |k, (old, new)|
+        %h3.control-label= k.titleize
+        %div= diff old, new
+
+  :css
+    = #{Diffy::CSS}


### PR DESCRIPTION
Moving "Proposal Diff" section to reviewers' page because this information doesn't provide any value to proposal submitters, and indeed this feature was initially requested for reviewers' page according to #23.

Thanks @koic for pointing this out!