### PR TITLE
budnle u mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ ruby File.read(".ruby-version").strip
 gem 'puma'
 gem 'rails', '~> 8.0.0'
 gem 'logger'
-gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
+gem 'mimemagic'
 gem 'mime-types-data'
 gem 'mime-types'
 gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/mimemagicrb/mimemagic.git
-  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
-  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
-  specs:
-    mimemagic (0.3.5)
-
 GEM
   remote: https://rails-assets.org/
   specs:
@@ -316,6 +309,9 @@ GEM
       logger
       mime-types-data (~> 3.2015)
     mime-types-data (3.2025.0304)
+    mimemagic (0.4.3)
+      nokogiri (~> 1)
+      rake
     mini_magick (5.1.2)
       benchmark
       logger
@@ -628,7 +624,7 @@ DEPENDENCIES
   matrix
   mime-types
   mime-types-data
-  mimemagic!
+  mimemagic
   net-imap
   net-pop
   net-smtp


### PR DESCRIPTION
mimemagic version has been locked since bfe03509f766a67c47e5ed5df2111b5fe1e932b7 without explaining why this revision, so let's try updating to the newest released gem and see what's going to happen.