### PR TITLE
"Missing template staff/grids/schedule.json.jbuilder"

### DIFF
--- a/app/views/staff/grids/show.html.haml
+++ b/app/views/staff/grids/show.html.haml
@@ -1,1 +1,1 @@
-= react_component('Schedule', render(template: "staff/grids/schedule.json.jbuilder"))
+= react_component('Schedule', render(template: "staff/grids/schedule", formats: [:json]))


### PR DESCRIPTION
with {locale: [:en], formats: [:html], variants: [], handlers: [:raw, :erb, :html, :builder, :ruby, :haml, :jbuilder]

I don't understand why this doesn't happen in the tests (maybe this page is not covered?), but we're seeing this in production.