### PR TITLE
Use field name instead of id for parse_edit_field

### DIFF
--- a/app/assets/javascripts/proposal.js
+++ b/app/assets/javascripts/proposal.js
@@ -5,7 +5,7 @@ $(function() {
     $('.watched').blur(function() {
       $.ajax({
         data: {
-          id: this.id,
+          name: this.name,
           text: $(this).val()
         },
         url: url

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -131,7 +131,7 @@ class ProposalsController < ApplicationController
     respond_to do |format|
       format.js do
         render locals: {
-          field_id: params[:id],
+          field_name: params[:name],
           text: markdown(params[:text])
         }
       end

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -1,18 +1,18 @@
 .proposal-section
   %h3.control-label Abstract
-  .markdown{ data: { 'field-id' => 'proposal_abstract' } }
+  .markdown{ data: { 'field-name' => 'proposal[abstract]' } }
     = proposal.abstract_markdown
 
 %h2.fieldset-legend For Review Committee
 
 .proposal-section
   %h3.control-label Details
-  .markdown{ data: { 'field-id' => 'proposal_details' } }
+  .markdown{ data: { 'field-name' => 'proposal[details]' } }
     = proposal.details_markdown
 
 .proposal-section
   %h3.control-label Pitch
-  .markdown{ data: { 'field-id' => 'proposal_pitch' } }
+  .markdown{ data: { 'field-name' => 'proposal[pitch]' } }
     =proposal.pitch_markdown
 
 - if proposal.custom_fields.any?

--- a/app/views/proposals/parse_edit_field.js.erb
+++ b/app/views/proposals/parse_edit_field.js.erb
@@ -1,1 +1,1 @@
-$('[data-field-id=<%= field_id %>]')[0].innerHTML = '<%=j text %>';
+$('[data-field-name="<%= field_name %>"]')[0].innerHTML = '<%=j text %>';


### PR DESCRIPTION
because id won't be unique when having collection inputs like radio_buttons/checkboxes.