### PR TITLE
Removing unused action proposals/finalized_notification

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -19,23 +19,6 @@ class ProposalsController < ApplicationController
     }
   end
 
-  def finalized_notification
-    @proposal = proposal # because drapper won't set the instance variable
-
-    email_template = case @proposal.state
-      when Proposal::State::ACCEPTED
-        'accept_email'
-      when Proposal::State::REJECTED
-        'reject_email'
-      when Proposal::State::WAITLISTED
-        'waitlist_email'
-    end
-
-    markdown_string = render_to_string "staff/proposal_mailer/#{email_template}", layout: false, formats: :md
-
-    @body = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(markdown_string)
-  end
-
   def new
     if @event.closed?
       redirect_to event_path (@event)

--- a/app/views/proposals/finalized_notification.html.erb
+++ b/app/views/proposals/finalized_notification.html.erb
@@ -1,1 +1,0 @@
-<%= @body.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,6 @@ Rails.application.routes.draw do
       member { post :decline }
       member { post :update_notes }
       member { delete :destroy }
-      member { get :finalized_notification }
     end
 
     get 'parse_edit_field' => 'proposals#parse_edit_field', as: :parse_edit_field_proposal


### PR DESCRIPTION
This action is no longer in use since b4ff3fb70af5645c799f5966a88ff7cfaadeaaca, I guess.