### PR TITLE
Avoid including ApplicationHelper in a controller

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -109,13 +109,12 @@ class ProposalsController < ApplicationController
     end
   end
 
-  include ApplicationHelper
   def parse_edit_field
     respond_to do |format|
       format.js do
         render locals: {
           field_name: params[:name],
-          text: markdown(params[:text])
+          text: params[:text]
         }
       end
     end

--- a/app/views/proposals/parse_edit_field.js.erb
+++ b/app/views/proposals/parse_edit_field.js.erb
@@ -1,1 +1,1 @@
-$('[data-field-name="<%= field_name %>"]')[0].innerHTML = '<%=j text %>';
+$('[data-field-name="<%= field_name %>"]')[0].innerHTML = '<%=j markdown(text) %>';


### PR DESCRIPTION
Because this would define all helper methods as action_methods. Instead, let's call helper methods in view files as usual.