### PR TITLE
after_sign_in_path_for is not an action_method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,8 @@ class ApplicationController < ActionController::Base
   layout 'application'
   decorates_assigned :event
 
+  private
+
   def after_sign_in_path_for(user)
     if session[:pending_invite_accept_url]
       session[:pending_invite_accept_url]
@@ -45,8 +47,6 @@ class ApplicationController < ActionController::Base
       root_path
     end
   end
-
-  private
 
   def current_event
     @current_event ||= set_current_event(session[:current_event_id]) if session[:current_event_id]


### PR DESCRIPTION
Here's another non-action_method that is mistakenly defined as a public method in ApplicationController.