### PR TITLE
Duplicated method definitions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,10 +123,6 @@ class ApplicationController < ActionController::Base
     @proposal = @event.proposals.find_by!(uuid: params[:proposal_uuid] || params[:uuid])
   end
 
-  def require_website
-    redirect_to not_found_path and return unless current_website
-  end
-
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
     redirect_to(request.referrer || root_path)

--- a/app/models/bulk_time_slot.rb
+++ b/app/models/bulk_time_slot.rb
@@ -1,7 +1,8 @@
 class BulkTimeSlot
   include ActiveModel::Model
 
-  attr_accessor :event, :day, :rooms, :start_times, :duration, :session_format
+  attr_accessor :session_format
+  attr_reader :event, :day, :rooms, :start_times, :duration
   validates :day, :rooms, :start_times, :duration, presence: true
 
   def event=(event)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -32,8 +32,8 @@ class Proposal < ApplicationRecord
 
   has_paper_trail only: %i[title abstract details pitch]
 
-  attr_accessor :review_tags, :updating_user
-  attr_writer :tags
+  attr_accessor :updating_user
+  attr_writer :tags, :review_tags
 
   accepts_nested_attributes_for :public_comments, reject_if: proc { |comment_attributes| comment_attributes[:body].blank? }
   accepts_nested_attributes_for :speakers

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -32,7 +32,8 @@ class Proposal < ApplicationRecord
 
   has_paper_trail only: %i[title abstract details pitch]
 
-  attr_accessor :tags, :review_tags, :updating_user
+  attr_accessor :review_tags, :updating_user
+  attr_writer :tags
 
   accepts_nested_attributes_for :public_comments, reject_if: proc { |comment_attributes| comment_attributes[:body].blank? }
   accepts_nested_attributes_for :speakers

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,5 @@
 class Schedule
-  attr_reader :event, :slots
+  attr_reader :event
 
   def initialize(event)
     @event = event

--- a/app/models/time_slot.rb
+++ b/app/models/time_slot.rb
@@ -5,8 +5,6 @@ class TimeSlot < ApplicationRecord
   belongs_to :event
   belongs_to :sponsor, optional: true
 
-  attr_reader :session_duration
-
   DEFAULT_TIME = Time.current.beginning_of_day.change(hour: 9)
   DEFAULT_DURATION = 60 # minutes
   STANDARD_LENGTH = 40.minutes


### PR DESCRIPTION
This patch fixes duplicated method definitions that emits Ruby warnings.