### PR TITLE
Reduce `select count` queries

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -75,8 +75,8 @@ class EventDecorator < ApplicationDecorator
   end
 
   def confirmed_percent
-    if proposals.accepted.confirmed.count > 0
-      "#{((object.proposals.accepted.confirmed.count.to_f/object.proposals.accepted.count.to_f)*100).round(1)}%"
+    if (accepted_confirmed_count = proposals.accepted.confirmed.count) > 0
+      "#{((accepted_confirmed_count.to_f / object.proposals.accepted.count.to_f) * 100).round(1)}%"
     else
       "0%"
     end
@@ -98,8 +98,8 @@ class EventDecorator < ApplicationDecorator
   end
 
   def waitlisted_percent
-    if proposals.waitlisted.confirmed.count > 0
-      "#{((object.proposals.waitlisted.confirmed.count.to_f/object.proposals.waitlisted.count.to_f)*100).round(1)}%"
+    if (waitlisted_confirmed_count = proposals.waitlisted.confirmed.count) > 0
+      "#{((waitlisted_confirmed_count.to_f / object.proposals.waitlisted.count.to_f) * 100).round(1)}%"
     else
       "0%"
     end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -54,7 +54,7 @@ class EventDecorator < ApplicationDecorator
 
   def reviewed_percent
     if proposals.count > 1
-      "#{((object.proposals.rated.count.to_f/object.proposals.count.to_f)*100).round(1)}%"
+      "#{((object.proposals.rated.count.to_f/object.proposals.count)*100).round(1)}%"
     else
       "0%"
     end
@@ -76,7 +76,7 @@ class EventDecorator < ApplicationDecorator
 
   def confirmed_percent
     if (accepted_confirmed_count = proposals.accepted.confirmed.count) > 0
-      "#{((accepted_confirmed_count.to_f / object.proposals.accepted.count.to_f) * 100).round(1)}%"
+      "#{((accepted_confirmed_count.to_f / object.proposals.accepted.count) * 100).round(1)}%"
     else
       "0%"
     end
@@ -99,7 +99,7 @@ class EventDecorator < ApplicationDecorator
 
   def waitlisted_percent
     if (waitlisted_confirmed_count = proposals.waitlisted.confirmed.count) > 0
-      "#{((waitlisted_confirmed_count.to_f / object.proposals.waitlisted.count.to_f) * 100).round(1)}%"
+      "#{((waitlisted_confirmed_count.to_f / object.proposals.waitlisted.count) * 100).round(1)}%"
     else
       "0%"
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -150,7 +150,7 @@ class Event < ApplicationRecord
     missing_prereqs << "Event must have a start date" unless start_date
     missing_prereqs << "Event must have a end date" unless end_date
 
-    unless rooms.size > 0
+    unless rooms.exists?
       missing_prereqs << "Event must have at least one room"
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,34 +76,34 @@ class User < ApplicationRecord
   end
 
   def organizer?
-    organizer_events.count > 0
+    organizer_events.exists?
   end
 
   def organizer_for_event?(event)
     #Checks for role of organizer through teammates
-    teammates.organizer.for_event(event).size > 0
+    teammates.organizer.for_event(event).exists?
   end
 
   def staff_for?(event)
     #Checks for any role in the event through teammates
-    teammates.for_event(event).size > 0
+    teammates.for_event(event).exists?
   end
 
   def reviewer?
-    reviewer_events.count > 0
+    reviewer_events.exists?
   end
 
   def reviewer_for_event?(event)
     #Checks for role of reviewer through teammates
-    teammates.reviewer.for_event(event).size > 0
+    teammates.reviewer.for_event(event).exists?
   end
 
   def program_team?
-    teammates.program_team.size > 0
+    teammates.program_team.exists?
   end
 
   def program_team_for_event?(event)
-    teammates.program_team.for_event(event).size > 0
+    teammates.program_team.for_event(event).exists?
   end
 
   def rating_for(proposal, build_new = true)


### PR DESCRIPTION
This patch reduces `select count` queries by reusing counted values and by changing the queries from `count` to `exists?`.