### PR TITLE
Proposal.not.has_one :time_slot

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -15,7 +15,6 @@ class Proposal < ApplicationRecord
   has_many :invitations, dependent: :destroy
 
   belongs_to :event
-  has_one :time_slot
   has_one :program_session
   belongs_to :session_format
   belongs_to :track, optional: true


### PR DESCRIPTION
Calling this association causes:
> ERROR:  column time_slots.proposal_id does not exist (ActiveRecord::StatementInvalid)
