### PR TITLE
SessionFormat.not.has_many :time_slots

### DIFF
--- a/app/models/session_format.rb
+++ b/app/models/session_format.rb
@@ -1,6 +1,5 @@
 class SessionFormat < ApplicationRecord
   belongs_to :event
-  has_many :time_slots
   has_many :proposals
 
   has_one :session_format_config


### PR DESCRIPTION
Calling this association causes:
> ERROR:  column time_slots.session_format_id does not exist