### PR TITLE
Speaker.not.has_many :program_sessions

### DIFF
--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -34,7 +34,6 @@ class Speaker < ApplicationRecord
   belongs_to :program_session, optional: true
 
   has_many :proposals, through: :user
-  has_many :program_sessions
 
   serialize :info, type: Hash, coder: YAML
 


### PR DESCRIPTION
Calling this association causes:
> ERROR:  column program_sessions.speaker_id does not exist