### PR TITLE
Properly escape validation error messages

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -32,9 +32,8 @@ class ProfilesController < ApplicationController
 
   def incomplete_profile_msg
     if profile_errors = current_user.profile_errors
-      msg = 'Your profile is incomplete. Please correct the following: '
-      msg << profile_errors.full_messages.to_sentence + '.'
-      msg.html_safe
+      msg = 'Your profile is incomplete. Please correct the following: '.html_safe
+      msg << profile_errors.full_messages.to_sentence << '.'
     end
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -164,11 +164,10 @@ class ProposalsController < ApplicationController
   end
 
   def incomplete_profile_msg
-    if profile_errors = current_user.profile_errors
-      msg = "Before submitting a proposal your profile needs completing. Please correct the following: "
+    if (profile_errors = current_user.profile_errors)
+      msg = "Before submitting a proposal your profile needs completing. Please correct the following: ".html_safe
       msg << profile_errors.full_messages.to_sentence
-      msg << ". Visit #{view_context.link_to('My Profile', edit_profile_path)} to update."
-      msg.html_safe
+      msg << ". Visit " << view_context.link_to('My Profile', edit_profile_path) << " to update."
     end
   end
 end

--- a/spec/support/shared_examples/an_incomplete_profile_notifier.rb
+++ b/spec/support/shared_examples/an_incomplete_profile_notifier.rb
@@ -7,11 +7,11 @@ end
 
 RSpec.shared_examples_for 'an incomplete profile notifier' do
   let(:unconfirmed_email_msg) { " Email #{user.unconfirmed_email} needs confirmation" }
-  let(:blank_name_msg) { " Name can't be blank" }
-  let(:blank_email_msg) { " Email can't be blank" }
-  let(:blank_name_and_email_msg) { " Name can't be blank and Email can't be blank" }
+  let(:blank_name_msg) { " Name can&#39;t be blank" }
+  let(:blank_email_msg) { " Email can&#39;t be blank" }
+  let(:blank_name_and_email_msg) { " Name can&#39;t be blank and Email can&#39;t be blank" }
   let(:unconfirmed_email_and_blank_name_msg) do
-    " Name can't be blank and Email #{user.unconfirmed_email} needs confirmation"
+    " Name can&#39;t be blank and Email #{user.unconfirmed_email} needs confirmation"
   end
 
   context 'name is missing' do


### PR DESCRIPTION
This patch fixes an issue that some flash messages (that could include user inputs) weren't properly html-escaped.