### PR TITLE
Assert page contents before asserting anything else

### DIFF
--- a/spec/system/proposal_spec.rb
+++ b/spec/system/proposal_spec.rb
@@ -122,12 +122,12 @@ feature "Proposals", type: :system do
       before :each do
         go_to_new_proposal
         create_proposal
+        expect(page).to have_text("Your proposal has been submitted and may be reviewed at any time while the CFP is open.")
       end
 
       it "submits successfully" do
         expect(Proposal.last.abstract).to_not match('<p>')
         expect(Proposal.last.abstract).to_not match('</p>')
-        expect(page).to have_text("Your proposal has been submitted and may be reviewed at any time while the CFP is open.")
       end
 
       it "does not create an empty comment" do


### PR DESCRIPTION
This fixes sporadic test failures.