### PR TITLE
Assert page contents before asserting anything else

### DIFF
--- a/spec/system/staff/teammates_spec.rb
+++ b/spec/system/staff/teammates_spec.rb
@@ -55,8 +55,8 @@ feature "Staff Organizers can manage teammates", type: :system do
       select("reviewer", from: "Role")
       click_button "Invite"
 
-      expect(current_path).to eq(event_staff_edit_path(incomplete_event))
       expect(page).to have_content "You must set a contact email for this event before inviting teammates."
+      expect(current_path).to eq(event_staff_edit_path(incomplete_event))
     end
   end
 


### PR DESCRIPTION
This fixes another sporadic test failure.