### PR TITLE
Unbundle amazing_print

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,2 +1,0 @@
-require "amazing_print"
-AmazingPrint.irb!

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'amazing_print', require: false
   gem 'capybara', '~> 3.37'
   gem 'database_cleaner', '~> 2.1'
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,6 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    amazing_print (1.7.2)
     annotate (2.6.5)
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
@@ -583,7 +582,6 @@ PLATFORMS
 DEPENDENCIES
   actionview-encoded_mail_to
   active_model_serializers (~> 0.10.15)
-  amazing_print
   annotate
   aws-sdk-s3
   better_errors


### PR DESCRIPTION
Recent versions of irb are truly amazing without gems like this, and since we've updated .ruby_version of this app to the newest released Ruby, now we're on the newest irb.