### PR TITLE
Fix broken SQL in my-proposals

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -10,7 +10,7 @@ class ProposalsController < ApplicationController
 
   def index
     proposals = current_user.proposals.
-      select("*, (#{PublicComment.select('count(*)').where('proposal_id = proposals.id').to_sql}) as public_comments_count").
+      select("proposals.*, (#{PublicComment.select('count(*)').where('proposal_id = proposals.id').to_sql}) as public_comments_count").
       includes(:event, {speakers: :user}, :session_format).order(event_id: :desc).decorate.group_by {|p| p.event}
     invitations = current_user.pending_invitations.decorate.group_by {|inv| inv.proposal.event}
     events = (proposals.keys | invitations.keys).uniq


### PR DESCRIPTION
This patch fixes a broken SQL introduced via 1fd9052bfabc18380edc3fa384cd3f5a3e655882 that selects * when including some models that are not joined. We should have selected `proposals.*` instead.