### PR TITLE
Fix events#show layout: CFP Stats chart overflow and broken column ordering

### DIFF
--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -4,7 +4,7 @@
 
 .stats {
   width: 100%;
-  display: table;
+  display: block;
   padding: 0 0 0 10px;
   margin-top: .5em;
   margin-bottom: 1.9em;

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -24,7 +24,7 @@
         CFP
 
 .row.margin-top
-  .col-md-4.col-md-push-8
+  .col-md-4.order-md-2
     .event-info.event-info-block.callout
       .call-header
         .label.badge.text-bg-success.label-large.inline-block
@@ -59,6 +59,6 @@
         = pluralize(proposals_count, "proposal")
         = event.line_chart
 
-  .col-md-8.col-md-pull-4
+  .col-md-8.order-md-1
     .markdown
       = markdown(event.guidelines)


### PR DESCRIPTION
Two layout bugs on the public event page (events#show), both stemming from outdated CSS that didn't survive the Bootstrap 5 upgrade.

## 1. CFP Stats chart overflows into the guidelines text on resize

The "CFP Stats" line chart (Chartkick + Chart.js) is a **responsive** canvas that sizes itself to its parent's width. Its container .stats used display: table, and the CSS table-layout algorithm expands to fit content's intrinsic width instead of honoring width: 100%. On window resize this created a feedback loop — Chart.js drew a wider canvas, the table grew to fit it, Chart.js measured wider again — so the chart spilled out of its col-md-4 column and overlapped the proposal-guidelines text.

Fix: display: table → display: block on .stats, so the chart stays clamped to its column width. .stats is only ever used as this chart wrapper (the .stats .stat table-cell rules are dead — the styleguide uses #big_stats .stat), so nothing else is affected.

## 2. Dead Bootstrap 3 push/pull column classes

The two columns used col-md-push-8 / col-md-pull-4, which were removed in Bootstrap 4+. Under Bootstrap 5.3 they're no-ops, leaving the columns in raw source order (CFP status/stats on the left, guidelines on the right) instead of the intended layout.

Fix: Use order-md-* utilities to restore the intended layout — guidelines on the left, CFP status/stats sidebar on the
right — while keeping the status box first in t when columns stack on mobile.
