### PR TITLE
Restore blockquote styling in markdown display

### DIFF
--- a/app/assets/stylesheets/base/typography.css
+++ b/app/assets/stylesheets/base/typography.css
@@ -44,4 +44,14 @@
   ul {
     list-style-type: disc;
   }
+  blockquote {
+    padding: 5px 20px;
+    margin: 0 0 20px;
+    border-left: 5px solid var(--gray-lighter);
+
+    /* Redcarpet wraps quote content in <p>; drop the doubled bottom gap */
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
 }


### PR DESCRIPTION
## What

The Bootstrap 3 -> 5 migration dropped the bare blockquote border-left and padding that Bootstrap 3 provided by default, leaving markdown-rendered quotes (comments, internal comments, proposal bodies) with no visual indication. Add a scoped `.markdown blockquote` rule to bring back the left border and indentation.

## Screenshots

| before | after |
| --- | --- |
| <img width="1577" height="1199" alt="image" src="https://github.com/user-attachments/assets/81ee1acb-0e55-436c-b4dc-cf9f37be4189" /> | <img width="1584" height="1171" alt="image" src="https://github.com/user-attachments/assets/545aefe0-554b-4f0e-a3c4-5dabb74d79e8" /> |



