### PR TITLE
Add `'data-turbo' => 'false'`  in markdown link to escape turbo-frames

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
   end
 
   MARKDOWN_RENDERER = Redcarpet::Markdown.new(
-    MarkdownRenderer.new(filter_html: true, hard_wrap: true),
+    MarkdownRenderer.new(filter_html: true, hard_wrap: true, link_attributes: { 'data-turbo' => 'false' }),
     fenced_code_blocks: true,
     no_intra_emphasis: true,
     autolink: true,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#markdown' do
+    it 'opts explicit links out of Turbo so they escape a surrounding turbo-frame' do
+      html = helper.markdown('see [example](https://example.com)')
+
+      expect(html).to include('href="https://example.com"')
+      expect(html).to include('data-turbo="false"')
+    end
+
+    it 'applies the same attribute to autolinked bare URLs' do
+      html = helper.markdown('visit https://example.com now')
+
+      expect(html).to include('data-turbo="false"')
+    end
+  end
+end


### PR DESCRIPTION
## What

Links inside internal comments live within the rating widget's turbo-frame, so clicking a comment URL triggered a frame navigation whose response lacked that frame, rendering "Content missing".


## Screenshots
### before
https://github.com/user-attachments/assets/26eee15a-8a02-4492-aa19-7e5bec6660b4

### after
https://github.com/user-attachments/assets/1d5c5eb1-3722-4eb8-ab7a-497f140cdf46

## ref
* #741 
    * regression from it maybe
