### PR TITLE
Wrap overflowed long text in comment field

### DIFF
--- a/app/assets/stylesheets/modules/discussions.css
+++ b/app/assets/stylesheets/modules/discussions.css
@@ -63,7 +63,10 @@ textarea.mention {
   .text {
     width: 100%;
     border-top: 1px solid var(--gray-light);
-    padding-top: 5px
+    padding-top: 5px;
+    overflow-wrap: anywhere;
+    word-break: normal;
+    line-break: strict;
   }
 }
 


### PR DESCRIPTION
## Screenshots

| before | after |
| --- | --- |
| <img width="452" height="164" alt="スクリーンショット 2026-07-12 010046" src="https://github.com/user-attachments/assets/959d85a0-4049-4827-b0a1-25ede3f470a1" /> | <img width="443" height="197" alt="スクリーンショット 2026-07-12 010145" src="https://github.com/user-attachments/assets/46e44c2f-b35e-4f11-b8dc-370f6b05d91d" /> |
