### PR TITLE
Style improvements for proposal pages

### DIFF
--- a/app/assets/stylesheets/base/typography.css
+++ b/app/assets/stylesheets/base/typography.css
@@ -41,6 +41,11 @@
   h1:first-child, h2:first-child {
     margin-top: 0;
   }
+  /* Keep user-authored headings subordinate to the page structure */
+  h1 { font-size: 1.3em; }
+  h2 { font-size: 1.2em; }
+  h3 { font-size: 1.1em; }
+  h4, h5, h6 { font-size: 1em; }
   ul {
     list-style-type: disc;
   }

--- a/app/assets/stylesheets/base/typography.css
+++ b/app/assets/stylesheets/base/typography.css
@@ -59,4 +59,8 @@
       margin-bottom: 0;
     }
   }
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 }

--- a/app/assets/stylesheets/modules/proposal.css
+++ b/app/assets/stylesheets/modules/proposal.css
@@ -3,6 +3,18 @@
   margin-bottom: 1em;
 }
 
+/* Section headings (Abstract, Details, Pitch, ...) on proposal pages. */
+/* Scoped to direct children so form labels and key-value labels */
+/* elsewhere keep the plain .control-label style. */
+.proposal-section > .control-label {
+  /* Beat `div.col-md-4 h3 { display: inline-block }` below so the */
+  /* border spans the full column width on the staff review page */
+  display: block;
+  font-size: calc(var(--font-size-base) * 1.35);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--legend-border-color);
+}
+
 .speaker {
   > h1, > h2, > h3, > h4 {
     margin-top: 0;

--- a/app/assets/stylesheets/modules/proposal.css
+++ b/app/assets/stylesheets/modules/proposal.css
@@ -264,4 +264,9 @@ div.col-md-4 {
   margin-bottom: 10px;
   padding-bottom: 10px;
   border-bottom: 1px solid grey;
+
+  summary {
+    cursor: pointer;
+    font-weight: bold;
+  }
 }

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -25,8 +25,9 @@
 
 - unless proposal.changeset_fields.blank?
   %h2.fieldset-legend Proposal Diff...
-  - proposal.versions.each do |version|
-    #diff-view
+  - proposal.versions.each.with_index(1) do |version, index|
+    %details.diff-view{ open: index == proposal.versions.size }
+      %summary= version.created_at.to_fs(:day_at_time)
       - version.changeset.each do |k, (old, new)|
         %h3.control-label= k.titleize
         %div= diff old, new


### PR DESCRIPTION
## What

- Scale down user-authored markdown headings and underline section headings (Abstract, Details, ...) so they no longer invert the visual hierarchy
- Constrain markdown images to container width to prevent overflow
- Make proposal diff versions collapsible, keeping only the latest open; also fixes the `#diff-view` / `.diff-view` selector mismatch

## screenshots
| before | after |
| --- | --- |
| <img width="1857" height="2524" alt="2026-07-24 15 50 56 127 0 0 1 9c96c8b8cf35" src="https://github.com/user-attachments/assets/6f494dee-8169-44a9-ba55-5037580cab82" /> | <img width="1872" height="2029" alt="2026-07-24 15 51 17 127 0 0 1 caf71ee63263" src="https://github.com/user-attachments/assets/8cad082e-bdaf-4308-9c35-093d29b262ee" /> |