### PR TITLE
Reduce queries for deriving proposal diffs and cache it

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -95,7 +95,7 @@ class Proposal < ApplicationRecord
   serialize :last_change, coder: YAML
   serialize :proposal_data, type: Hash, coder: YAML
 
-  has_paper_trail only: %i[title abstract details pitch]
+  has_paper_trail only: %i[title abstract details pitch], versions: { inverse_of: :item }
 
   attr_accessor :updating_user
   attr_writer :tags, :review_tags

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -28,9 +28,11 @@
   - proposal.versions.each.with_index(1) do |version, index|
     %details.diff-view{ open: index == proposal.versions.size }
       %summary= version.created_at.to_fs(:day_at_time)
-      - version.changeset.each do |k, (old, new)|
-        %h3.control-label= k.titleize
-        %div= diff old, new
+      -# Versions are immutable, so the rendered diff can be cached forever.
+      - cache version do
+        - version.changeset.each do |k, (old, new)|
+          %h3.control-label= k.titleize
+          %div= diff old, new
 
   :css
     = #{Diffy::CSS}


### PR DESCRIPTION
## What
During our review process, we occasionally encountered request timeouts. The proposals causing timeouts had a lot of  change histories. After creating similar data locally and conducting verification, we discovered that N+1 queries were being generated.
This pull request addresses the N+1 query issue, includes caching to prevent timeouts since the diff content remains unchanged.

## Screenshots
### before
<img width="1183" height="716" alt="image" src="https://github.com/user-attachments/assets/6dc125f4-c4d6-4965-b782-eae9fa253e65" />

### after
<img width="935" height="185" alt="image" src="https://github.com/user-attachments/assets/65199a6d-7e00-4545-a116-c95688c2c0ab" />
