### PR TITLE
Stop installing google-chrome-stable in CI for silence noisy warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libvips postgresql-client libpq-dev imagemagick
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y curl libvips postgresql-client libpq-dev imagemagick
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What

The runner image ships Chrome and a matching chromedriver, but installing google-chrome-stable upgrades Chrome only, leaving the older chromedriver in PATH and making Selenium Manager warn about the version mismatch.

### before
https://github.com/rubycentral/cfp-app/actions/runs/30789221013/job/91609087212
<img width="1081" height="764" alt="image" src="https://github.com/user-attachments/assets/5299fcea-fc5c-49a2-8b1c-e10bb1c35579" />

### after
https://github.com/rubycentral/cfp-app/actions/runs/30790184107/job/91611847026
<img width="1488" height="792" alt="image" src="https://github.com/user-attachments/assets/28958563-6f12-4700-9cec-fd4fdd0befbe" />
