### PR TITLE
Watch github actions updates by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What
CI currently emits the following warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<img width="829" height="308" alt="image" src="https://github.com/user-attachments/assets/92217eca-1bf7-46d0-bf2a-c85990c8829d" />


Dependabot only covered `bundler` and `npm`, so action version bumps had to be noticed and applied by hand. Adding the `github-actions` ecosystem lets us follow deprecations like this one through pull requests instead.